### PR TITLE
ci: enforce actionlint as a failing gate and fix its shellcheck findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,16 @@ jobs:
           fetch-depth: 0
       - id: last_release
         name: Fetch last release info
-        run: echo "tag=$(gh release view --json tagName --jq '.tagName')" >> $GITHUB_OUTPUT
+        run: echo "tag=$(gh release view --json tagName --jq '.tagName')" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: commits
         name: Count Commits
-        run: echo "count=$(git rev-list --count ${{ steps.last_release.outputs.tag }}..HEAD -- go.mod main.go internal api config Dockerfile)" >> $GITHUB_OUTPUT
+        run: echo "count=$(git rev-list --count ${{ steps.last_release.outputs.tag }}..HEAD -- go.mod main.go internal api config Dockerfile)" >> "$GITHUB_OUTPUT"
       - id: release
         name: Create Release Version
         if: steps.commits.outputs.count > 0 || steps.last_release.outputs.tag == ''
-        run: echo "version=$(date +'%Y.%-m.%-d')" >> $GITHUB_OUTPUT
+        run: echo "version=$(date +'%Y.%-m.%-d')" >> "$GITHUB_OUTPUT"
   build:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     needs: prepare
@@ -159,7 +159,7 @@ jobs:
         run: |
           cd dist
           shopt -s nullglob
-          sha256sum *.tar.gz *.zip > ${{ github.event.repository.name }}_${{ needs.prepare.outputs.release_version }}_SHA256SUMS
+          sha256sum ./*.tar.gz ./*.zip > "${{ github.event.repository.name }}_${{ needs.prepare.outputs.release_version }}_SHA256SUMS"
       - id: sign_checksums
         name: Sign Checksums (cosign keyless)
         if: needs.prepare.outputs.commit_count > 0 || needs.prepare.outputs.previous_version == ''
@@ -266,7 +266,7 @@ jobs:
       - id: timestamp
         if: needs.prepare.outputs.commit_count > 0 || needs.prepare.outputs.previous_version == ''
         name: Create Timestamp
-        run: echo "date=$(date --rfc-3339=seconds)" >> $GITHUB_OUTPUT
+        run: echo "date=$(date --rfc-3339=seconds)" >> "$GITHUB_OUTPUT"
       - id: publish
         if: needs.prepare.outputs.commit_count > 0 || needs.prepare.outputs.previous_version == ''
         name: Publish Image

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -112,6 +112,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
+        with:
+          fail_on_error: true
+          filter_mode: nofilter
   markdown:
     runs-on: ubuntu-latest
     steps:

--- a/dev/Containerfile
+++ b/dev/Containerfile
@@ -10,7 +10,7 @@ FROM docker.io/library/golang:1.26.4@sha256:87a41d2539e5671777734e91f467499ed5ea
 # toolchain than this base image without a Containerfile change.
 ENV GOTOOLCHAIN=auto
 
-RUN apt-get update && apt-get install -y git curl jq reuse yamllint
+RUN apt-get update && apt-get install -y git curl jq reuse yamllint shellcheck
 
 # markdownlint-cli2 mirrors the DavidAnson/markdownlint-cli2-action used in
 # verify.yml, so `markdownlint-cli2 '**/*.md'` reproduces the CI markdown gate


### PR DESCRIPTION
actionlint ran via reviewdog with the default fail_on_error: false, so shellcheck findings on workflow run: steps were posted as PR annotations but never failed CI. Set fail_on_error: true and filter_mode: nofilter so they fail repo-wide, fix the existing findings in release.yml (quote $GITHUB_OUTPUT — SC2086; ./*-prefix the sha256sum globs — SC2035), and install shellcheck in the dev image so actionlint reproduces the CI gate locally.