### PR TITLE
ci: serialize release runs so quick successive releases don't share n…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+# Serialize release runs. Each run's release-notes lower bound is the latest tag
+# at the time its prepare job runs; two merges in quick succession would both
+# read that bound before either run has tagged, producing overlapping notes.
+# Queueing (no cancel) lets the earlier release finish and create its tag first,
+# so the next run's notes start from that tag and carry only its own commits.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   prepare:
     name: Prepare Release


### PR DESCRIPTION
…otes

Each run computes its release-notes lower bound (the latest tag) in the prepare job, seconds after the triggering merge. Two merges in quick succession both read that bound before either run reaches its github job and creates a tag, so both generate notes from the same prior tag and the two releases carry nearly identical, overlapping notes.

Add a concurrency group that queues release runs (cancel-in-progress: false) instead of running them in parallel. The earlier release finishes and creates its tag first, so the next run's prepare sees that tag and its notes start there — each release carries only its own commits. Moving the notes calculation later would not fix this: if the two github jobs interleave, the later-triggered run can still tag first and overlap; serializing the runs is what guarantees ordering.