### PR TITLE
test(smoke): real NetworkPolicy enforcement under Calico/Cilium + Clu…

### DIFF
--- a/.github/workflows/kind-smoke.yml
+++ b/.github/workflows/kind-smoke.yml
@@ -781,6 +781,100 @@ jobs:
           kubectl describe jsonnetsnippet np-smoke || true
           kubectl describe externalartifact np-smoke || true
 
+  # Real NetworkPolicy enforcement under a CNI that actually enforces (kindnet,
+  # used by the `networkpolicy` job above, does not). Each chart engine is run on
+  # the matching CNI: the kubernetes engine on Calico gets the full allow+deny
+  # assertion (the storage-port allowlist scopes ingress to flux-system, so a
+  # fetch from another namespace is genuinely dropped); the calico / cilium
+  # engines render a pod-scoped allow-all on the required ports (no per-source
+  # filter to deny), so they assert allow + operator-works under their native
+  # dialect; the clusterNetworkPolicy engine (policy.networking.k8s.io/v1alpha2)
+  # has no on-kind enforcer yet, so its CRDs are installed and the dialect is
+  # validated at apply level. Cluster is created with no default CNI so the real
+  # one can be installed (kind --wait 0s: nodes go Ready only after that).
+  networkpolicy-enforcement:
+    name: NetworkPolicy enforced (${{ matrix.cni }} / ${{ matrix.engine }})
+    needs: discover
+    if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cni: calico
+            engine: kubernetes
+            kindcfg: kind-calico.yaml
+            enforce: "1"
+          - cni: calico
+            engine: calico
+            kindcfg: kind-calico.yaml
+            enforce: "0"
+          - cni: cilium
+            engine: cilium
+            kindcfg: kind-cilium.yaml
+            enforce: "0"
+          - cni: calico
+            engine: clusterNetworkPolicy
+            kindcfg: kind-calico.yaml
+            enforce: "0"
+    steps:
+      - name: Clone Git Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build container image (dev / HEAD)
+        run: docker build --build-arg VERSION=smoke --build-arg COMMIT=${{ github.sha }} -t jaas:smoke .
+      - name: Create kind cluster (no default CNI)
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
+        with:
+          version: ${{ needs.discover.outputs.kind_latest }}
+          cluster_name: jaas-npe
+          node_image: kindest/node:${{ needs.discover.outputs.k8s_latest }}
+          config: hack/smoke/${{ matrix.kindcfg }}
+          wait: "0s"
+      - name: Install the enforcing CNI (${{ matrix.cni }})
+        run: hack/smoke/setup-${{ matrix.cni }}.sh
+      - name: Install the Network Policy API CRDs (clusterNetworkPolicy engine)
+        if: matrix.engine == 'clusterNetworkPolicy'
+        run: hack/smoke/setup-networkpolicy-api.sh
+      - name: Load image into kind
+        run: kind load docker-image jaas:smoke --name jaas-npe
+      - name: Cluster prereqs (Flux)
+        run: hack/smoke/setup-flux.sh ${{ needs.discover.outputs.flux_latest }}
+      - name: Install released chart (NetworkPolicy enabled, engine=${{ matrix.engine }}) with the dev image
+        run: |
+          kubectl create namespace jaas-system
+          helm upgrade --install jaas oci://ghcr.io/metio/helm-charts/jaas \
+            --version "${{ needs.discover.outputs.chart_version }}" \
+            --namespace jaas-system \
+            --set image.registry=docker.io \
+            --set image.repository=library/jaas \
+            --set-string image.tag=smoke \
+            --set operator.enabled=true \
+            --set operator.defaultServiceAccount=default \
+            --set libraries.grafonnet.enabled=false \
+            --set libraries.docsonnet.enabled=false \
+            --set libraries.xtd.enabled=false \
+            --set networkPolicy.enabled=true \
+            --set networkPolicy.engine=${{ matrix.engine }} \
+            --wait --timeout 5m
+          kubectl apply --server-side --force-conflicts -f config/crd/bases/
+      - name: Operator scenario — NetworkPolicy enforcement
+        run: ENFORCE=${{ matrix.enforce }} hack/smoke/scenario-networkpolicy-enforcement.sh
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n jaas-system get all || true
+          kubectl get networkpolicies.networking.k8s.io -A -o wide || true
+          kubectl get ciliumnetworkpolicies.cilium.io -A -o wide || true
+          kubectl get networkpolicies.projectcalico.org -A -o wide || true
+          kubectl get clusternetworkpolicies.policy.networking.k8s.io -A -o wide || true
+          kubectl -n jaas-system logs deploy/jaas --tail=300 || true
+          kubectl describe jsonnetsnippet np-enforce || true
+
   # Single stably-named aggregate — the only check to mark "required". It always
   # runs (if: always()) so it reports on every PR, including ones where the kind
   # jobs skip (not operator-relevant, or no released chart yet) — those pass.
@@ -798,6 +892,7 @@ jobs:
       - image-volume
       - impersonation
       - networkpolicy
+      - networkpolicy-enforcement
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/hack/smoke/kind-calico.yaml
+++ b/hack/smoke/kind-calico.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# kind cluster with no default CNI, so Calico can be installed as the CNI that
+# actually ENFORCES NetworkPolicy (kind's built-in kindnet does not). podSubnet
+# is 192.168.0.0/16 to match Calico's default IP pool (manifests/calico.yaml), so
+# pod networking comes up without extra IPAM configuration.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: "192.168.0.0/16"

--- a/hack/smoke/kind-cilium.yaml
+++ b/hack/smoke/kind-cilium.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# kind cluster with no default CNI so Cilium can be installed as the CNI that
+# actually ENFORCES NetworkPolicy (kind's built-in kindnet does not). Cilium is
+# installed with ipam.mode=kubernetes, so it uses the nodes' PodCIDRs and the
+# kind-default podSubnet is left in place (no override needed here).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true

--- a/hack/smoke/lib.sh
+++ b/hack/smoke/lib.sh
@@ -129,6 +129,23 @@ fetch_artifact() {
     --image=docker.io/curlimages/curl:8.10.1 "smoke-curl-$$" -- sh -c "$script"
 }
 
+# fetch_artifact_denied <url> <from-ns> — fail unless fetching the artifact from
+# a throwaway pod in <from-ns> is BLOCKED. The counterpart to fetch_artifact:
+# under an enforcing CNI the chart's storage-port allowlist admits only
+# flux-system, so a fetch from any other namespace must be dropped. A SUCCESSFUL
+# fetch means the allowlist is NOT being enforced. The short connect timeout
+# makes a dropped dial fail fast instead of hanging on the default timeout; the
+# curl image is pinned and long-form per repo convention.
+fetch_artifact_denied() {
+  local url=$1 ns=$2
+  if kubectl -n "$ns" run --rm -i --restart=Never \
+      --image=docker.io/curlimages/curl:8.10.1 "smoke-deny-$$" \
+      -- curl -fsS --connect-timeout 8 --max-time 15 "$url" -o /dev/null; then
+    die "artifact was reachable from $ns — the storage-port allowlist is NOT enforcing (it should admit only flux-system)"
+  fi
+  log "artifact correctly BLOCKED from $ns (storage-port allowlist enforced)"
+}
+
 # has_event <name> <ns> <type> <reason> — true if a matching event exists.
 has_event() {
   kubectl -n "$2" get events --field-selector "involvedObject.name=$1" \

--- a/hack/smoke/scenario-networkpolicy-enforcement.sh
+++ b/hack/smoke/scenario-networkpolicy-enforcement.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# Scenario: the chart's NetworkPolicy is actually ENFORCED by a real CNI — what
+# scenario-networkpolicy.sh cannot test, because kind's default kindnet treats
+# NetworkPolicy as a no-op. The calling workflow installs an enforcing CNI
+# (Calico / Cilium) and the chart with networkPolicy.enabled=true and
+# networkPolicy.engine matching the CNI. It is deliberately engine-AGNOSTIC: it
+# asserts traffic behaviour, not a specific policy object kind.
+#
+# It pins:
+#   1. the operator still reconciles a snippet to Ready under the rendered
+#      policy + real CNI (the dialect applies and does not break the operator);
+#   2. ALLOW: the published artifact is reachable on the storage port from an
+#      admitted namespace (flux-system) — the allowlist re-permits the real Flux
+#      consumers under enforcement;
+#   3. DENY (ENFORCE=1): the same artifact is NOT reachable from a non-admitted
+#      namespace. The chart's kubernetes-engine allowlist scopes the storage port
+#      to flux-system, so under a real CNI a fetch from the snippet's own
+#      namespace is dropped. This is the true-negative the kindnet job can't make.
+#
+# ENFORCE=0 keeps only the allow + operator assertions. It is used where the
+# rendered dialect is pod-scoped allow-all on the required ports (the chart's
+# cilium / calico engines apply no per-source filter, so there is no per-source
+# deny to assert), and for the clusterNetworkPolicy engine whose v1alpha2 API has
+# no on-kind enforcer yet (the CRDs are installed so the objects apply and the
+# operator path is exercised — apply-level validation).
+#
+# Env: JAAS_NS (install namespace; default jaas-system), NS / NAME (snippet
+# namespace / name), ENFORCE (1 = also assert deny, 0 = allow + apply only).
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=hack/smoke/lib.sh
+. "$DIR/lib.sh"
+JAAS_NS="${JAAS_NS:-jaas-system}"
+NS="${NS:-default}"
+NAME="${NAME:-np-enforce}"
+ENFORCE="${ENFORCE:-1}"
+log "install namespace: $JAAS_NS (engine policy is rendered there)"
+
+log "the operator must reconcile a snippet with the policy in place under a real CNI"
+grant_tenant_publish_rbac "$NS"
+apply_retry <<EOF
+apiVersion: jaas.metio.wtf/v1
+kind: JsonnetSnippet
+metadata: { name: ${NAME}, namespace: ${NS} }
+spec:
+  serviceAccountName: default
+  entryFile: main.jsonnet
+  files:
+    main.jsonnet: |
+      { networkPolicy: "enforced", ok: true }
+EOF
+wait_ready jsonnetsnippet "$NAME" "$NS"
+
+log "ALLOW: the artifact must be reachable on the storage port from an admitted namespace (flux-system)"
+URL="$(ea_url "$NAME" "$NS")"
+[ -n "$URL" ] || die "snippet $NAME published no ExternalArtifact URL"
+log "ExternalArtifact URL: $URL"
+fetch_artifact "$URL" '"networkPolicy": "enforced"' flux-system
+
+if [ "$ENFORCE" = "1" ]; then
+  log "DENY: the storage port must be BLOCKED from a non-admitted namespace ($NS)"
+  fetch_artifact_denied "$URL" "$NS"
+else
+  log "ENFORCE=0: skipping the deny assertion (dialect is allow-all on the ports, or has no on-kind enforcer)"
+fi
+
+kubectl -n "$NS" delete jsonnetsnippet "$NAME" --timeout=120s || true
+log "scenario-networkpolicy-enforcement PASSED (ENFORCE=$ENFORCE)"

--- a/hack/smoke/setup-calico.sh
+++ b/hack/smoke/setup-calico.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# Install Calico as the enforcing CNI on a disableDefaultCNI kind cluster (see
+# kind-calico.yaml). kind's built-in kindnet does NOT enforce NetworkPolicy;
+# Calico does — both the vanilla networking.k8s.io NetworkPolicy and its own
+# projectcalico.org dialect — so it backs the chart's `kubernetes` and `calico`
+# engines for the enforcement smoke. The manifest's default IP pool is
+# 192.168.0.0/16, which matches kind-calico.yaml's podSubnet. Nodes only go
+# Ready once the CNI is up, so this waits for that. Usage:
+#   setup-calico.sh [calico-version]
+set -euo pipefail
+VERSION="${1:-v3.29.1}"
+
+kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${VERSION}/manifests/calico.yaml"
+kubectl -n kube-system rollout status daemonset/calico-node --timeout=300s
+kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=300s
+kubectl wait --for=condition=Ready nodes --all --timeout=300s

--- a/hack/smoke/setup-calico.sh
+++ b/hack/smoke/setup-calico.sh
@@ -4,16 +4,46 @@
 #
 # Install Calico as the enforcing CNI on a disableDefaultCNI kind cluster (see
 # kind-calico.yaml). kind's built-in kindnet does NOT enforce NetworkPolicy;
-# Calico does — both the vanilla networking.k8s.io NetworkPolicy and its own
-# projectcalico.org dialect — so it backs the chart's `kubernetes` and `calico`
-# engines for the enforcement smoke. The manifest's default IP pool is
-# 192.168.0.0/16, which matches kind-calico.yaml's podSubnet. Nodes only go
-# Ready once the CNI is up, so this waits for that. Usage:
-#   setup-calico.sh [calico-version]
+# Calico does. This uses the Tigera operator install (the recommended path)
+# rather than the flat calico.yaml manifest, because the chart's `calico` engine
+# renders projectcalico.org/v3 NetworkPolicy — the AGGREGATED Calico API, served
+# by the calico-apiserver, which only the operator install (APIServer CR) brings
+# up. The operator install also enforces vanilla networking.k8s.io NetworkPolicy,
+# so it backs the chart's `kubernetes` engine too, and serves as the CNI for the
+# clusterNetworkPolicy apply-level job. Usage: setup-calico.sh [calico-version]
 set -euo pipefail
 VERSION="${1:-v3.29.1}"
 
-kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${VERSION}/manifests/calico.yaml"
-kubectl -n kube-system rollout status daemonset/calico-node --timeout=300s
-kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=300s
-kubectl wait --for=condition=Ready nodes --all --timeout=300s
+kubectl create -f "https://raw.githubusercontent.com/projectcalico/calico/${VERSION}/manifests/tigera-operator.yaml"
+kubectl -n tigera-operator rollout status deployment/tigera-operator --timeout=180s
+
+# Installation pins the IP pool to kind-calico.yaml's podSubnet; APIServer turns
+# on the projectcalico.org/v3 aggregated API so engine=calico objects apply.
+kubectl create -f - <<'EOF'
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  calicoNetwork:
+    ipPools:
+      - cidr: 192.168.0.0/16
+        encapsulation: VXLANCrossSubnet
+        natOutgoing: Enabled
+---
+apiVersion: operator.tigera.io/v1
+kind: APIServer
+metadata:
+  name: default
+spec: {}
+EOF
+
+# tigerastatus is the operator's aggregate health (calico-node + apiserver +
+# ippools). It is created once the operator reconciles, so wait for the resource
+# to appear before waiting on its Available condition.
+for _ in $(seq 1 60); do
+  kubectl get tigerastatus >/dev/null 2>&1 && break
+  sleep 5
+done
+kubectl wait --for=condition=Available tigerastatus --all --timeout=420s
+kubectl wait --for=condition=Ready nodes --all --timeout=420s

--- a/hack/smoke/setup-calico.sh
+++ b/hack/smoke/setup-calico.sh
@@ -38,12 +38,19 @@ metadata:
 spec: {}
 EOF
 
-# tigerastatus is the operator's aggregate health (calico-node + apiserver +
-# ippools). It is created once the operator reconciles, so wait for the resource
-# to appear before waiting on its Available condition.
-for _ in $(seq 1 60); do
-  kubectl get tigerastatus >/dev/null 2>&1 && break
+# Wait for the projectcalico.org/v3 aggregated API (calico-apiserver) to be
+# served — exactly what engine=calico needs. `kubectl get
+# networkpolicies.projectcalico.org` errors ("server doesn't have a resource
+# type") until the calico-apiserver is registered and the aggregation layer is
+# healthy, then exits 0 (empty list). This is more robust than waiting on
+# tigerastatus, which the CRD makes list-able (exit 0) before the operator has
+# created any instance — so a `kubectl wait --all` there races to "no matching
+# resources found".
+for _ in $(seq 1 120); do
+  kubectl get networkpolicies.projectcalico.org -A >/dev/null 2>&1 && break
   sleep 5
 done
-kubectl wait --for=condition=Available tigerastatus --all --timeout=420s
+kubectl get networkpolicies.projectcalico.org -A >/dev/null 2>&1 \
+  || { echo "projectcalico.org/v3 API never became available" >&2; kubectl get tigerastatus >&2 || true; exit 1; }
+# calico-node makes the nodes Ready once the CNI is up.
 kubectl wait --for=condition=Ready nodes --all --timeout=420s

--- a/hack/smoke/setup-cilium.sh
+++ b/hack/smoke/setup-cilium.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# Install Cilium as the enforcing CNI on a disableDefaultCNI kind cluster (see
+# kind-cilium.yaml). kind's built-in kindnet does NOT enforce NetworkPolicy;
+# Cilium does — both the vanilla networking.k8s.io NetworkPolicy and its own
+# CiliumNetworkPolicy dialect — so it backs the chart's `cilium` engine for the
+# enforcement smoke. ipam.mode=kubernetes makes Cilium use the nodes' PodCIDRs
+# (the kind default). Nodes only go Ready once the CNI is up, so this waits for
+# that. Usage: setup-cilium.sh [cilium-chart-version]
+set -euo pipefail
+VERSION="${1:-1.16.5}"
+
+helm repo add cilium https://helm.cilium.io >/dev/null
+helm repo update >/dev/null
+helm install cilium cilium/cilium --version "${VERSION}" --namespace kube-system \
+  --set image.pullPolicy=IfNotPresent \
+  --set ipam.mode=kubernetes
+kubectl -n kube-system rollout status daemonset/cilium --timeout=300s
+kubectl wait --for=condition=Ready nodes --all --timeout=300s

--- a/hack/smoke/setup-networkpolicy-api.sh
+++ b/hack/smoke/setup-networkpolicy-api.sh
@@ -2,25 +2,25 @@
 # SPDX-FileCopyrightText: The jaas Authors
 # SPDX-License-Identifier: 0BSD
 #
-# Install the SIG-Network "Network Policy API" CRDs (policy.networking.k8s.io),
-# which define ClusterNetworkPolicy (v1alpha2) — the API the chart renders for
-# networkPolicy.engine=clusterNetworkPolicy. Installing the CRDs lets the
-# apiserver accept the chart's ClusterNetworkPolicy objects, so the engine's
-# dialect is validated against the REAL schema (kubeconform only ignores it as a
-# missing schema, and helm-unittest just renders it).
+# Install the SIG-Network "Network Policy API" ClusterNetworkPolicy CRD
+# (policy.networking.k8s.io/v1alpha2) — the API the chart renders for
+# networkPolicy.engine=clusterNetworkPolicy. Installing it lets the apiserver
+# accept the chart's ClusterNetworkPolicy objects, so the dialect is validated
+# against the REAL schema (kubeconform only ignores it as a missing schema, and
+# helm-unittest just renders it).
+#
+# The CRD comes from the project's STANDARD channel (not experimental), for
+# long-term stability: the standard channel serves v1alpha2 and is the set that
+# graduates toward GA, so this tracks the supported shape. The releases ship no
+# install.yaml, so the single channel CRD file is applied by raw URL at a pinned
+# tag.
 #
 # This installs the API only, NOT an enforcer: on kind there is no controller
-# that enforces v1alpha2 ClusterNetworkPolicy yet (the API merged ANP/BANP in
-# late 2025 and is still pre-v1beta1). So engine=clusterNetworkPolicy is
-# validated at APPLY level — objects accepted + the operator unaffected — not by
-# traffic enforcement. The latest release is resolved at runtime so the CRD set
-# tracks the evolving alpha API. Usage: setup-networkpolicy-api.sh [api-version]
+# that enforces v1alpha2 ClusterNetworkPolicy yet, so engine=clusterNetworkPolicy
+# is validated at APPLY level — the objects are accepted and the operator is
+# unaffected — not by traffic enforcement. Usage:
+#   setup-networkpolicy-api.sh [api-version]
 set -euo pipefail
-VERSION="${1:-}"
-if [ -z "${VERSION}" ]; then
-  VERSION="$(curl -fsSL https://api.github.com/repos/kubernetes-sigs/network-policy-api/releases/latest \
-    | grep -oP '"tag_name":\s*"\K[^"]+')"
-fi
-[ -n "${VERSION}" ] || { echo "could not resolve a network-policy-api release version" >&2; exit 1; }
-echo "installing network-policy-api CRDs ${VERSION}" >&2
-kubectl apply -f "https://github.com/kubernetes-sigs/network-policy-api/releases/download/${VERSION}/install.yaml"
+VERSION="${1:-v0.2.0}"
+echo "installing network-policy-api ClusterNetworkPolicy CRD (standard channel) ${VERSION}" >&2
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/${VERSION}/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml"

--- a/hack/smoke/setup-networkpolicy-api.sh
+++ b/hack/smoke/setup-networkpolicy-api.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# Install the SIG-Network "Network Policy API" CRDs (policy.networking.k8s.io),
+# which define ClusterNetworkPolicy (v1alpha2) — the API the chart renders for
+# networkPolicy.engine=clusterNetworkPolicy. Installing the CRDs lets the
+# apiserver accept the chart's ClusterNetworkPolicy objects, so the engine's
+# dialect is validated against the REAL schema (kubeconform only ignores it as a
+# missing schema, and helm-unittest just renders it).
+#
+# This installs the API only, NOT an enforcer: on kind there is no controller
+# that enforces v1alpha2 ClusterNetworkPolicy yet (the API merged ANP/BANP in
+# late 2025 and is still pre-v1beta1). So engine=clusterNetworkPolicy is
+# validated at APPLY level — objects accepted + the operator unaffected — not by
+# traffic enforcement. The latest release is resolved at runtime so the CRD set
+# tracks the evolving alpha API. Usage: setup-networkpolicy-api.sh [api-version]
+set -euo pipefail
+VERSION="${1:-}"
+if [ -z "${VERSION}" ]; then
+  VERSION="$(curl -fsSL https://api.github.com/repos/kubernetes-sigs/network-policy-api/releases/latest \
+    | grep -oP '"tag_name":\s*"\K[^"]+')"
+fi
+[ -n "${VERSION}" ] || { echo "could not resolve a network-policy-api release version" >&2; exit 1; }
+echo "installing network-policy-api CRDs ${VERSION}" >&2
+kubectl apply -f "https://github.com/kubernetes-sigs/network-policy-api/releases/download/${VERSION}/install.yaml"


### PR DESCRIPTION
…sterNetworkPolicy

The existing networkpolicy smoke runs on kind's default kindnet, which treats NetworkPolicy as a no-op — so it only proves the policy object applies, never that it blocks. Add a networkpolicy-enforcement matrix that creates a kind cluster with no default CNI, installs a CNI that actually enforces, and runs the chart's policy dialect against it:

- calico / engine=kubernetes — full allow+deny: the storage-port allowlist scopes ingress to flux-system, so a fetch from another namespace is genuinely dropped (fetch_artifact_denied), while flux-system still reaches it.
- calico / engine=calico and cilium / engine=cilium — the native dialects render a pod-scoped allow-all on the required ports (no per-source filter), so they assert allow + operator-works under real enforcement.
- calico / engine=clusterNetworkPolicy — installs the network-policy-api (policy.networking.k8s.io/v1alpha2) CRDs and validates the dialect at apply level; v1alpha2 ClusterNetworkPolicy has no on-kind enforcer yet, so a traffic deny would be fiction.

New shared bits in hack/smoke: kind-calico.yaml / kind-cilium.yaml (no default CNI), setup-calico.sh / setup-cilium.sh / setup-networkpolicy-api.sh, the engine-agnostic scenario-networkpolicy-enforcement.sh, and a fetch_artifact_denied helper. The aggregate System Tests job gains the new job.