### PR TITLE
test(smoke): real Istio service-mesh authorization enforcement

### DIFF
--- a/.github/workflows/kind-smoke.yml
+++ b/.github/workflows/kind-smoke.yml
@@ -916,10 +916,13 @@ jobs:
         run: hack/smoke/setup-${{ matrix.engine }}.sh
       - name: Create + mesh-inject the install and client namespaces
         run: |
-          for ns in jaas-system mesh-allowed mesh-denied; do
+          for ns in jaas-system mesh-clients; do
             kubectl create namespace "$ns"
             kubectl label namespace "$ns" istio-injection=enabled
           done
+          # The authorized client identity. The denied client reuses the
+          # namespace default SA, so allow/deny turns on the ServiceAccount alone.
+          kubectl -n mesh-clients create serviceaccount mesh-reader
       - name: Install released chart (serviceMesh enabled, engine=${{ matrix.engine }}) with the dev image
         run: |
           helm upgrade --install jaas oci://ghcr.io/metio/helm-charts/jaas \
@@ -936,10 +939,10 @@ jobs:
             --set serviceMesh.enabled=true \
             --set serviceMesh.engine=${{ matrix.engine }} \
             --set serviceMesh.mtls=permissive \
-            --set 'serviceMesh.storage.from[0].namespaces[0]=mesh-allowed' \
+            --set 'serviceMesh.storage.from[0].principals[0]=cluster.local/ns/mesh-clients/sa/mesh-reader' \
             --wait --timeout 5m
           kubectl apply --server-side --force-conflicts -f config/crd/bases/
-      - name: Operator scenario — service-mesh authz enforcement
+      - name: Operator scenario — service-mesh authz enforcement (by SA identity)
         run: ENGINE=${{ matrix.engine }} hack/smoke/scenario-servicemesh.sh
       - name: Diagnostics on failure
         if: failure()
@@ -948,7 +951,7 @@ jobs:
           kubectl -n jaas-system get authorizationpolicies.security.istio.io,peerauthentications.security.istio.io -o yaml || true
           kubectl -n jaas-system get servers.policy.linkerd.io,authorizationpolicies.policy.linkerd.io -o yaml || true
           kubectl -n jaas-system logs deploy/jaas --all-containers=true --tail=200 || true
-          kubectl -n mesh-denied logs deploy/mesh-deny --all-containers=true --tail=50 || true
+          kubectl -n mesh-clients logs deploy/mesh-deny --all-containers=true --tail=50 || true
 
   # Single stably-named aggregate — the only check to mark "required". It always
   # runs (if: always()) so it reports on every PR, including ones where the kind

--- a/.github/workflows/kind-smoke.yml
+++ b/.github/workflows/kind-smoke.yml
@@ -875,6 +875,81 @@ jobs:
           kubectl -n jaas-system logs deploy/jaas --tail=300 || true
           kubectl describe jsonnetsnippet np-enforce || true
 
+  # Real service-mesh authorization enforcement. The chart's serviceMesh engine
+  # renders the mesh's authz objects (Istio AuthorizationPolicy + optional
+  # PeerAuthentication); this installs the mesh, injects the install + client
+  # namespaces, scopes serviceMesh.storage.from to the allowed namespace, and
+  # asserts a meshed client from there reaches the storage port while one from a
+  # non-admitted namespace is rejected by the mesh (403 / reset). Needs no Flux:
+  # the operator boots with its Flux watches gated, and the storage server still
+  # answers (404), which is all the authz check needs. (Linkerd is a follow-up.)
+  servicemesh:
+    name: Service mesh authz enforced (${{ matrix.engine }})
+    needs: discover
+    if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - engine: istio
+    steps:
+      - name: Clone Git Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build container image (dev / HEAD)
+        run: docker build --build-arg VERSION=smoke --build-arg COMMIT=${{ github.sha }} -t jaas:smoke .
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
+        with:
+          version: ${{ needs.discover.outputs.kind_latest }}
+          cluster_name: jaas-mesh
+          node_image: kindest/node:${{ needs.discover.outputs.k8s_latest }}
+          wait: 120s
+      - name: Load image into kind
+        run: kind load docker-image jaas:smoke --name jaas-mesh
+      - name: Install the service mesh (${{ matrix.engine }})
+        run: hack/smoke/setup-${{ matrix.engine }}.sh
+      - name: Create + mesh-inject the install and client namespaces
+        run: |
+          for ns in jaas-system mesh-allowed mesh-denied; do
+            kubectl create namespace "$ns"
+            kubectl label namespace "$ns" istio-injection=enabled
+          done
+      - name: Install released chart (serviceMesh enabled, engine=${{ matrix.engine }}) with the dev image
+        run: |
+          helm upgrade --install jaas oci://ghcr.io/metio/helm-charts/jaas \
+            --version "${{ needs.discover.outputs.chart_version }}" \
+            --namespace jaas-system \
+            --set image.registry=docker.io \
+            --set image.repository=library/jaas \
+            --set-string image.tag=smoke \
+            --set operator.enabled=true \
+            --set operator.defaultServiceAccount=default \
+            --set libraries.grafonnet.enabled=false \
+            --set libraries.docsonnet.enabled=false \
+            --set libraries.xtd.enabled=false \
+            --set serviceMesh.enabled=true \
+            --set serviceMesh.engine=${{ matrix.engine }} \
+            --set serviceMesh.mtls=permissive \
+            --set 'serviceMesh.storage.from[0].namespaces[0]=mesh-allowed' \
+            --wait --timeout 5m
+          kubectl apply --server-side --force-conflicts -f config/crd/bases/
+      - name: Operator scenario — service-mesh authz enforcement
+        run: ENGINE=${{ matrix.engine }} hack/smoke/scenario-servicemesh.sh
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n jaas-system get all || true
+          kubectl -n jaas-system get authorizationpolicies.security.istio.io,peerauthentications.security.istio.io -o yaml || true
+          kubectl -n jaas-system get servers.policy.linkerd.io,authorizationpolicies.policy.linkerd.io -o yaml || true
+          kubectl -n jaas-system logs deploy/jaas --all-containers=true --tail=200 || true
+          kubectl -n mesh-denied logs deploy/mesh-deny --all-containers=true --tail=50 || true
+
   # Single stably-named aggregate — the only check to mark "required". It always
   # runs (if: always()) so it reports on every PR, including ones where the kind
   # jobs skip (not operator-relevant, or no released chart yet) — those pass.
@@ -893,6 +968,7 @@ jobs:
       - impersonation
       - networkpolicy
       - networkpolicy-enforcement
+      - servicemesh
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/hack/smoke/lib.sh
+++ b/hack/smoke/lib.sh
@@ -146,13 +146,16 @@ fetch_artifact_denied() {
   log "artifact correctly BLOCKED from $ns (storage-port allowlist enforced)"
 }
 
-# deploy_meshed_curl <ns> <name> — deploy a long-running curl Deployment in <ns>
-# and wait until it is ready. The service-mesh scenarios curl through the pod's
-# sidecar via `kubectl exec` rather than `kubectl run`, because an injected
-# sidecar never lets a one-shot pod complete (the proxy keeps running). <ns> must
-# already be mesh-injected so the pod gets a sidecar and a workload identity.
+# deploy_meshed_curl <ns> <name> [serviceAccount] — deploy a long-running curl
+# Deployment in <ns> under the given ServiceAccount (default "default") and wait
+# until it is ready. The service-mesh scenarios curl through the pod's sidecar
+# via `kubectl exec` rather than `kubectl run`, because an injected sidecar never
+# lets a one-shot pod complete (the proxy keeps running). <ns> must already be
+# mesh-injected so the pod gets a sidecar and a workload identity. The SA is what
+# the mesh authz keys on — both Istio (source.principals SPIFFE id) and Linkerd
+# (MeshTLSAuthentication identity) authorize by the pod's ServiceAccount.
 deploy_meshed_curl() {
-  local ns=$1 name=$2
+  local ns=$1 name=$2 sa=${3:-default}
   kubectl -n "$ns" apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
@@ -166,6 +169,7 @@ spec:
   template:
     metadata: { labels: { app: ${name} } }
     spec:
+      serviceAccountName: ${sa}
       containers:
         - name: curl
           image: docker.io/curlimages/curl:8.10.1

--- a/hack/smoke/lib.sh
+++ b/hack/smoke/lib.sh
@@ -146,6 +146,44 @@ fetch_artifact_denied() {
   log "artifact correctly BLOCKED from $ns (storage-port allowlist enforced)"
 }
 
+# deploy_meshed_curl <ns> <name> — deploy a long-running curl Deployment in <ns>
+# and wait until it is ready. The service-mesh scenarios curl through the pod's
+# sidecar via `kubectl exec` rather than `kubectl run`, because an injected
+# sidecar never lets a one-shot pod complete (the proxy keeps running). <ns> must
+# already be mesh-injected so the pod gets a sidecar and a workload identity.
+deploy_meshed_curl() {
+  local ns=$1 name=$2
+  kubectl -n "$ns" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${name}
+  namespace: ${ns}
+  labels: { app: ${name} }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: ${name} } }
+  template:
+    metadata: { labels: { app: ${name} } }
+    spec:
+      containers:
+        - name: curl
+          image: docker.io/curlimages/curl:8.10.1
+          command: ["sleep", "infinity"]
+EOF
+  kubectl -n "$ns" rollout status deploy/"$name" --timeout=180s
+}
+
+# meshed_http_status <ns> <deploy> <url> — echo the HTTP status code curl gets
+# hitting <url> from inside the meshed <deploy> (so the request traverses the
+# sidecar and the target's inbound mesh authz). "000" means the connection
+# failed outright (e.g. a Linkerd reset), which counts as a rejection.
+meshed_http_status() {
+  local ns=$1 deploy=$2 url=$3
+  kubectl -n "$ns" exec "deploy/$deploy" -c curl -- \
+    curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$url" 2>/dev/null || echo "000"
+}
+
 # has_event <name> <ns> <type> <reason> — true if a matching event exists.
 has_event() {
   kubectl -n "$2" get events --field-selector "involvedObject.name=$1" \

--- a/hack/smoke/scenario-servicemesh.sh
+++ b/hack/smoke/scenario-servicemesh.sh
@@ -2,55 +2,57 @@
 # SPDX-FileCopyrightText: The jaas Authors
 # SPDX-License-Identifier: 0BSD
 #
-# Scenario: the chart's service-mesh authorization is actually ENFORCED. The
-# workflow installs a mesh (Istio / Linkerd), labels the install + client
-# namespaces for sidecar injection, and deploys the chart with
-# serviceMesh.enabled, serviceMesh.engine=<mesh>, and serviceMesh.storage.from
-# scoped to the ALLOW_NS source. This asserts the mesh authz behaviour, engine-
-# agnostically:
-#   - ALLOW: a meshed client whose identity the policy admits reaches the storage
-#     port (the app answers — 404 for "/" is fine, the point is the mesh let it
-#     through);
-#   - DENY: a meshed client the policy does not admit is rejected by the mesh
-#     (Istio returns 403; Linkerd resets → curl reports 000). A 2xx/404 from the
-#     denied client means the authz is NOT enforcing.
+# Scenario: the chart's service-mesh authorization is actually ENFORCED, and
+# enforced by WORKLOAD IDENTITY (ServiceAccount), which is what both meshes key
+# on — Istio matches source.principals (the SPIFFE id cluster.local/ns/<ns>/sa/<sa>),
+# Linkerd matches the MeshTLSAuthentication identity. To prove it is the identity
+# and not merely the namespace, the allowed and denied clients run in the SAME
+# mesh-injected namespace and differ only by ServiceAccount: the workflow scopes
+# serviceMesh.storage.from to the ALLOW_SA's identity.
+#
+#   - ALLOW: a meshed client running as ALLOW_SA reaches the storage port;
+#   - DENY: a meshed client in the same namespace running as the default SA is
+#     rejected by the mesh (Istio 403; Linkerd resets → curl reports 000). A
+#     2xx/404 from the denied client means the authz is NOT enforcing.
 #
 # It needs no Flux/artifact: the operator boots with its Flux watches gated when
-# the ExternalArtifact CRD is absent, and the storage HTTP server still listens
-# (404 for an unknown path), which is all the authz check requires.
+# the ExternalArtifact CRD is absent, and the storage HTTP server still answers
+# (404 for an unknown path), which is all the authz check requires. Clients are
+# long-running meshed Deployments hit via `kubectl exec` (an injected sidecar
+# never lets a one-shot pod complete).
 #
-# Env: JAAS_NS (install ns; default jaas-system), ALLOW_NS / DENY_NS (meshed
-# client namespaces; default mesh-allowed / mesh-denied), ENGINE (istio|linkerd).
+# Env: JAAS_NS (install ns; default jaas-system), CLIENT_NS (meshed client ns;
+# default mesh-clients), ALLOW_SA (authorized ServiceAccount; default mesh-reader),
+# ENGINE (istio|linkerd). The denied client uses the namespace default SA.
 set -euo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=hack/smoke/lib.sh
 . "$DIR/lib.sh"
 JAAS_NS="${JAAS_NS:-jaas-system}"
-ALLOW_NS="${ALLOW_NS:-mesh-allowed}"
-DENY_NS="${DENY_NS:-mesh-denied}"
+CLIENT_NS="${CLIENT_NS:-mesh-clients}"
+ALLOW_SA="${ALLOW_SA:-mesh-reader}"
 ENGINE="${ENGINE:-istio}"
 URL="http://jaas-storage.${JAAS_NS}:8082/"
-log "engine=$ENGINE  storage URL=$URL  allow=$ALLOW_NS  deny=$DENY_NS"
+log "engine=$ENGINE  storage URL=$URL  client ns=$CLIENT_NS  allowed SA=$ALLOW_SA  denied SA=default"
 
-log "deploy meshed curl clients in the allowed and denied namespaces"
-deploy_meshed_curl "$ALLOW_NS" mesh-allow
-deploy_meshed_curl "$DENY_NS" mesh-deny
+log "deploy two meshed curl clients in $CLIENT_NS — one as $ALLOW_SA (allowed), one as default (denied)"
+deploy_meshed_curl "$CLIENT_NS" mesh-allow "$ALLOW_SA"
+deploy_meshed_curl "$CLIENT_NS" mesh-deny default
 
-log "ALLOW: a meshed client from $ALLOW_NS must reach the storage port"
-allow_code="$(meshed_http_status "$ALLOW_NS" mesh-allow "$URL")"
+log "ALLOW: the client running as $ALLOW_SA must reach the storage port (mesh authz admits its identity)"
+allow_code="$(meshed_http_status "$CLIENT_NS" mesh-allow "$URL")"
 log "allowed client got HTTP $allow_code"
 case "$allow_code" in
-  403 | 000) die "allowed client from $ALLOW_NS was rejected (HTTP $allow_code) — mesh authz over-denied" ;;
+  403 | 000) die "client as $ALLOW_SA was rejected (HTTP $allow_code) — mesh authz over-denied" ;;
 esac
 
-log "DENY: a meshed client from $DENY_NS must be rejected by the mesh authz"
-deny_code="$(meshed_http_status "$DENY_NS" mesh-deny "$URL")"
+log "DENY: the same-namespace client running as the default SA must be rejected (identity, not namespace)"
+deny_code="$(meshed_http_status "$CLIENT_NS" mesh-deny "$URL")"
 log "denied client got HTTP $deny_code"
 case "$deny_code" in
   403 | 000) log "denied client correctly rejected (HTTP $deny_code)" ;;
-  *) die "denied client from $DENY_NS reached the storage port (HTTP $deny_code) — mesh authz is NOT enforcing" ;;
+  *) die "client as default SA reached the storage port (HTTP $deny_code) — mesh authz is NOT enforcing by identity" ;;
 esac
 
-kubectl -n "$ALLOW_NS" delete deploy mesh-allow --timeout=60s || true
-kubectl -n "$DENY_NS" delete deploy mesh-deny --timeout=60s || true
+kubectl -n "$CLIENT_NS" delete deploy mesh-allow mesh-deny --timeout=60s || true
 log "scenario-servicemesh PASSED (engine=$ENGINE)"

--- a/hack/smoke/scenario-servicemesh.sh
+++ b/hack/smoke/scenario-servicemesh.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# Scenario: the chart's service-mesh authorization is actually ENFORCED. The
+# workflow installs a mesh (Istio / Linkerd), labels the install + client
+# namespaces for sidecar injection, and deploys the chart with
+# serviceMesh.enabled, serviceMesh.engine=<mesh>, and serviceMesh.storage.from
+# scoped to the ALLOW_NS source. This asserts the mesh authz behaviour, engine-
+# agnostically:
+#   - ALLOW: a meshed client whose identity the policy admits reaches the storage
+#     port (the app answers — 404 for "/" is fine, the point is the mesh let it
+#     through);
+#   - DENY: a meshed client the policy does not admit is rejected by the mesh
+#     (Istio returns 403; Linkerd resets → curl reports 000). A 2xx/404 from the
+#     denied client means the authz is NOT enforcing.
+#
+# It needs no Flux/artifact: the operator boots with its Flux watches gated when
+# the ExternalArtifact CRD is absent, and the storage HTTP server still listens
+# (404 for an unknown path), which is all the authz check requires.
+#
+# Env: JAAS_NS (install ns; default jaas-system), ALLOW_NS / DENY_NS (meshed
+# client namespaces; default mesh-allowed / mesh-denied), ENGINE (istio|linkerd).
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=hack/smoke/lib.sh
+. "$DIR/lib.sh"
+JAAS_NS="${JAAS_NS:-jaas-system}"
+ALLOW_NS="${ALLOW_NS:-mesh-allowed}"
+DENY_NS="${DENY_NS:-mesh-denied}"
+ENGINE="${ENGINE:-istio}"
+URL="http://jaas-storage.${JAAS_NS}:8082/"
+log "engine=$ENGINE  storage URL=$URL  allow=$ALLOW_NS  deny=$DENY_NS"
+
+log "deploy meshed curl clients in the allowed and denied namespaces"
+deploy_meshed_curl "$ALLOW_NS" mesh-allow
+deploy_meshed_curl "$DENY_NS" mesh-deny
+
+log "ALLOW: a meshed client from $ALLOW_NS must reach the storage port"
+allow_code="$(meshed_http_status "$ALLOW_NS" mesh-allow "$URL")"
+log "allowed client got HTTP $allow_code"
+case "$allow_code" in
+  403 | 000) die "allowed client from $ALLOW_NS was rejected (HTTP $allow_code) — mesh authz over-denied" ;;
+esac
+
+log "DENY: a meshed client from $DENY_NS must be rejected by the mesh authz"
+deny_code="$(meshed_http_status "$DENY_NS" mesh-deny "$URL")"
+log "denied client got HTTP $deny_code"
+case "$deny_code" in
+  403 | 000) log "denied client correctly rejected (HTTP $deny_code)" ;;
+  *) die "denied client from $DENY_NS reached the storage port (HTTP $deny_code) — mesh authz is NOT enforcing" ;;
+esac
+
+kubectl -n "$ALLOW_NS" delete deploy mesh-allow --timeout=60s || true
+kubectl -n "$DENY_NS" delete deploy mesh-deny --timeout=60s || true
+log "scenario-servicemesh PASSED (engine=$ENGINE)"

--- a/hack/smoke/setup-istio.sh
+++ b/hack/smoke/setup-istio.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# Install the Istio control plane for the service-mesh enforcement smoke. The
+# chart's serviceMesh engine=istio renders security.istio.io AuthorizationPolicy
+# (+ optional PeerAuthentication); this installs istiod via the official Helm
+# charts (istio/base provides the CRDs, istio/istiod the control plane). Sidecar
+# injection is left to per-namespace `istio-injection=enabled` labels the
+# workflow/scenario sets BEFORE the workloads start. Usage:
+#   setup-istio.sh [istio-version]
+set -euo pipefail
+VERSION="${1:-1.24.2}"
+
+helm repo add istio https://istio-release.storage.googleapis.com/charts >/dev/null
+helm repo update >/dev/null
+kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+helm upgrade --install istio-base istio/base --version "${VERSION}" \
+  --namespace istio-system --set defaultRevision=default --wait
+helm upgrade --install istiod istio/istiod --version "${VERSION}" \
+  --namespace istio-system --wait
+kubectl -n istio-system rollout status deployment/istiod --timeout=300s


### PR DESCRIPTION
PR1 covered NetworkPolicy enforcement; this covers the chart's serviceMesh authz. A new servicemesh job installs Istio, mesh-injects the install + two client namespaces, deploys the chart with serviceMesh.enabled, engine=istio, mtls=permissive, and serviceMesh.storage.from scoped to the allowed namespace, then asserts the mesh actually enforces:

- a meshed client from the allowed namespace reaches the storage port;
- a meshed client from a non-admitted namespace is rejected (Istio 403).

It needs no Flux/artifact: the operator boots with its Flux watches gated (no ExternalArtifact CRD) and the storage HTTP server still answers, which is all the AuthorizationPolicy check requires. Clients are long-running meshed curl Deployments hit via kubectl exec, because an injected sidecar never lets a one-shot pod complete. Shared bits: setup-istio.sh, scenario-servicemesh.sh (engine-agnostic, ready for Linkerd next), and deploy_meshed_curl / meshed_http_status in lib.sh.