### PR TITLE
test(smoke): add Linkerd to the service-mesh authz enforcement matrix

### DIFF
--- a/.github/workflows/kind-smoke.yml
+++ b/.github/workflows/kind-smoke.yml
@@ -893,6 +893,9 @@ jobs:
       matrix:
         include:
           - engine: istio
+            principal: cluster.local/ns/mesh-clients/sa/mesh-reader
+          - engine: linkerd
+            principal: mesh-reader.mesh-clients.serviceaccount.identity.linkerd.cluster.local
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -918,7 +921,10 @@ jobs:
         run: |
           for ns in jaas-system mesh-clients; do
             kubectl create namespace "$ns"
+            # Mark for injection in both meshes' idioms — each marker is inert
+            # unless that mesh is installed, so the step stays engine-agnostic.
             kubectl label namespace "$ns" istio-injection=enabled
+            kubectl annotate namespace "$ns" linkerd.io/inject=enabled
           done
           # The authorized client identity. The denied client reuses the
           # namespace default SA, so allow/deny turns on the ServiceAccount alone.
@@ -939,7 +945,7 @@ jobs:
             --set serviceMesh.enabled=true \
             --set serviceMesh.engine=${{ matrix.engine }} \
             --set serviceMesh.mtls=permissive \
-            --set 'serviceMesh.storage.from[0].principals[0]=cluster.local/ns/mesh-clients/sa/mesh-reader' \
+            --set 'serviceMesh.storage.from[0].principals[0]=${{ matrix.principal }}' \
             --wait --timeout 5m
           kubectl apply --server-side --force-conflicts -f config/crd/bases/
       - name: Operator scenario — service-mesh authz enforcement (by SA identity)

--- a/hack/smoke/setup-linkerd.sh
+++ b/hack/smoke/setup-linkerd.sh
@@ -7,22 +7,28 @@
 # MeshTLSAuthentication objects. Installed via the Linkerd CLI, which
 # auto-generates the mTLS trust anchor + issuer (the Helm install would require
 # supplying them out of band). Sidecar injection is by the linkerd.io/inject
-# annotation the workflow sets on the namespaces, not by this script. Usage:
-#   setup-linkerd.sh [linkerd-version]   # e.g. edge-25.x.x / stable-2.x.x
+# annotation the workflow sets on the namespaces, not by this script.
+#
+# The CLI version is pinned (run.linkerd.io installs edge releases only now, a
+# fast-moving target) for a reproducible smoke. Recent Linkerd builds its policy
+# CRDs on the Gateway API, so those CRDs must be installed BEFORE
+# `linkerd install --crds` — otherwise it refuses and emits nothing. Usage:
+#   setup-linkerd.sh [linkerd-edge-version]
 set -euo pipefail
-VERSION="${1:-}"
+VERSION="${1:-edge-26.6.3}"
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.2.1}"
 # The installer (run via `| sh`) reads INSTALLROOT and LINKERD2_VERSION from the
 # environment, so both are exported for the child shell to inherit. INSTALLROOT
 # keeps the CLI self-contained under ~/.linkerd2/bin.
 export INSTALLROOT="${HOME}/.linkerd2"
-if [ -n "${VERSION}" ]; then
-  export LINKERD2_VERSION="${VERSION}"
-fi
-curl --proto '=https' --tlsv1.2 -fsSL https://run.linkerd.io/install | sh
+export LINKERD2_VERSION="${VERSION}"
+curl --proto '=https' --tlsv1.2 -fsSL https://run.linkerd.io/install-edge | sh
 export PATH="${INSTALLROOT}/bin:${PATH}"
-
 linkerd version --client
-# CRDs first (split out since Linkerd 2.12), then the control plane.
+
+# Linkerd's policy resources extend the Gateway API; its CRDs must exist first.
+kubectl apply --server-side -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+# Linkerd CRDs (split out since 2.12), then the control plane.
 linkerd install --crds | kubectl apply -f -
 linkerd install | kubectl apply -f -
 linkerd check --wait=5m

--- a/hack/smoke/setup-linkerd.sh
+++ b/hack/smoke/setup-linkerd.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The jaas Authors
+# SPDX-License-Identifier: 0BSD
+#
+# Install Linkerd for the service-mesh enforcement smoke. The chart's serviceMesh
+# engine=linkerd renders policy.linkerd.io Server / AuthorizationPolicy /
+# MeshTLSAuthentication objects. Installed via the Linkerd CLI, which
+# auto-generates the mTLS trust anchor + issuer (the Helm install would require
+# supplying them out of band). Sidecar injection is by the linkerd.io/inject
+# annotation the workflow sets on the namespaces, not by this script. Usage:
+#   setup-linkerd.sh [linkerd-version]   # e.g. edge-25.x.x / stable-2.x.x
+set -euo pipefail
+VERSION="${1:-}"
+# The installer (run via `| sh`) reads INSTALLROOT and LINKERD2_VERSION from the
+# environment, so both are exported for the child shell to inherit. INSTALLROOT
+# keeps the CLI self-contained under ~/.linkerd2/bin.
+export INSTALLROOT="${HOME}/.linkerd2"
+if [ -n "${VERSION}" ]; then
+  export LINKERD2_VERSION="${VERSION}"
+fi
+curl --proto '=https' --tlsv1.2 -fsSL https://run.linkerd.io/install | sh
+export PATH="${INSTALLROOT}/bin:${PATH}"
+
+linkerd version --client
+# CRDs first (split out since Linkerd 2.12), then the control plane.
+linkerd install --crds | kubectl apply -f -
+linkerd install | kubectl apply -f -
+linkerd check --wait=5m


### PR DESCRIPTION
Extends the servicemesh job to Linkerd, reusing the engine-agnostic scenario-servicemesh.sh unchanged. setup-linkerd.sh installs Linkerd via its CLI (auto-generates the mTLS trust anchor + issuer). The matrix now carries a per-engine allowed principal — Istio's SPIFFE id
(cluster.local/ns/mesh-clients/sa/mesh-reader) vs Linkerd's identity (mesh-reader.mesh-clients.serviceaccount.identity.linkerd.cluster.local) — fed to serviceMesh.storage.from. Namespaces are marked for injection in both idioms (istio-injection label + linkerd.io/inject annotation), each inert unless its mesh is installed. Linkerd authorizes by the same workload identity, so the allow (mesh-reader SA) / deny (default SA) split and the 403-or-reset(000) rejection check already in the scenario both apply.