### PR TITLE
docs: add Flux HelmRelease + OCIRepository install with good defaults

### DIFF
--- a/docs/content/installation/kubernetes.md
+++ b/docs/content/installation/kubernetes.md
@@ -126,6 +126,57 @@ correct when downstream Flux consumers fetch artifacts from inside the cluster.
 Set it explicitly only when consumers dereference the artifacts through an
 Ingress or external hostname.
 
+### Install with Flux (GitOps)
+
+To manage JaaS from a Flux GitOps repository instead of `helm` on the command
+line, point an `OCIRepository` at the chart and install it with a `HelmRelease`.
+The `values:` block takes exactly the same keys as the `--values` file above —
+this example is the operator shape with local storage:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: jaas
+  namespace: jaas-system
+spec:
+  interval: 1h
+  url: oci://ghcr.io/metio/helm-charts/jaas
+  ref:
+    # Latest released chart. Pin to a specific tag for production; Renovate can
+    # keep the pin current.
+    semver: ">=0.0.0"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: jaas
+  namespace: jaas-system
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: jaas
+  values:
+    operator:
+      enabled: true
+      storage:
+        backend: local
+        persistence:
+          enabled: true
+          size: 10Gi
+```
+
+Both resources live in `jaas-system`, so the namespace must exist first: create
+it with `kubectl create namespace jaas-system`, or include a `Namespace` manifest
+alongside them. The source- and helm-controllers reconcile an `OCIRepository` and
+`HelmRelease` directly, so no wrapping `Kustomization` is required — apply the two
+with `kubectl apply -f`, or commit them to whatever Git/OCI source your Flux setup
+already syncs. For the HTTP-renderer shape, drop the `operator` block and set
+`snippets` / `libraries` under `values:` instead. `HelmRelease` gives you
+upgrades, rollbacks, and drift correction; pull the chart version forward by
+bumping the `OCIRepository` `ref`.
+
 ### Manage the CRDs
 
 The chart ships its CRDs (`JsonnetSnippet`, `JsonnetLibrary`) inside the regular

--- a/docs/content/usage/joi-images.md
+++ b/docs/content/usage/joi-images.md
@@ -13,6 +13,45 @@ snippet imports a vendored library without bundling it.
 
 Deploy them with the [joi Helm chart](/installation/helm-values/#joi-library-chart),
 which renders a `JsonnetLibrary` + `OCIRepository` pair for each enabled library.
+With Flux, install it via a `HelmRelease` and enable the libraries you need under
+`values.libraries`:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: joi
+  namespace: jaas-system
+spec:
+  interval: 1h
+  url: oci://ghcr.io/metio/helm-charts/joi
+  ref:
+    # Latest released chart; pin to a tag for production (Renovate can bump it).
+    semver: ">=0.0.0"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: joi
+  namespace: jaas-system
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: joi
+  values:
+    libraries:
+      k8s-libsonnet:
+        enabled: true
+      grafonnet:
+        enabled: true
+```
+
+Install it in the namespace where your snippets live: a `JsonnetLibrary` is
+namespaced, and a snippet references one in its own namespace. (`helm upgrade
+--install joi oci://ghcr.io/metio/helm-charts/joi --set
+libraries.grafonnet.enabled=true` does the same from the command line.)
+
 A snippet then imports a library by its alias, choosing the version in the import
 path:
 


### PR DESCRIPTION
The install page documented the helm CLI but not the GitOps path. Add an "Install with Flux" section to the Kubernetes install page (operator shape with local storage) and a HelmRelease example to the JOI usage page (enabling a couple of libraries), each as a copy-pasteable OCIRepository + HelmRelease against the published charts. Clarify that the two are reconciled directly — no wrapping Kustomization required — and that the namespace must exist first.