### PR TITLE
fix(cliflags): validate enum flags and tracing sample-ratio range

### DIFF
--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -14,6 +14,7 @@ package cliflags
 import (
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"time"
 
@@ -253,6 +254,29 @@ func (f *Flags) Validate() error {
 			return fmt.Errorf("%s must be >= 0, got %s", d.name, d.val)
 		}
 	}
+
+	if r := *f.TracingSampleRatio; r < 0 || r > 1 {
+		return fmt.Errorf("--tracing-sample-ratio must be in 0.0..1.0, got %v", r)
+	}
+
+	// Enumerated flags — an out-of-set value would otherwise fail deep in
+	// startup (or, for log-level/format, silently fall back) instead of as a
+	// clean usage error.
+	enums := []struct {
+		name, val string
+		allowed   []string
+	}{
+		{"--log-level", *f.LogLevel, []string{"debug", "info", "warn", "error"}},
+		{"--log-format", *f.LogFormat, []string{"json", "text"}},
+		{"--webhook-cert-mode", *f.WebhookCertMode, []string{"cert-manager", "self-signed"}},
+		{"--storage-backend", *f.StorageBackend, []string{"local", "s3"}},
+	}
+	for _, e := range enums {
+		if !slices.Contains(e.allowed, e.val) {
+			return fmt.Errorf("%s must be one of %v, got %q", e.name, e.allowed, e.val)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/cliflags/validate_test.go
+++ b/internal/cliflags/validate_test.go
@@ -93,6 +93,12 @@ func TestFlags_Validate_RejectsInvalid(t *testing.T) {
 			*f.EnableMCP = true
 			*f.MCPBindAddress = ""
 		}},
+		{"sample-ratio below zero", func(f *cliflags.Flags) { *f.TracingSampleRatio = -0.1 }},
+		{"sample-ratio above one", func(f *cliflags.Flags) { *f.TracingSampleRatio = 2.0 }},
+		{"log-level bogus", func(f *cliflags.Flags) { *f.LogLevel = "trace" }},
+		{"log-format bogus", func(f *cliflags.Flags) { *f.LogFormat = "yaml" }},
+		{"webhook-cert-mode bogus", func(f *cliflags.Flags) { *f.WebhookCertMode = "vault" }},
+		{"storage-backend bogus", func(f *cliflags.Flags) { *f.StorageBackend = "gcs" }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/main_envtest_test.go
+++ b/main_envtest_test.go
@@ -131,36 +131,25 @@ func TestRun_FluxIntegration_BindFailureOnStoragePort(t *testing.T) {
 	}
 }
 
-// TestRun_FluxIntegration_InvalidWebhookCertModeFailsWithExit1 pins the
-// --webhook-cert-mode enum: an unrecognised mode is rejected (exit 1) before
-// any listener binds, naming the two accepted values. The check sits inside
-// the --enable-flux-integration + --enable-webhook boot path, so it needs a
-// reachable apiserver to clear loadKubeconfig first.
-func TestRun_FluxIntegration_InvalidWebhookCertModeFailsWithExit1(t *testing.T) {
-	kubeconfig := envtestMainSetup(t)
-
+// TestRun_FluxIntegration_InvalidWebhookCertModeFailsWithExit2 pins the
+// --webhook-cert-mode enum: an unrecognised mode is a usage error caught by
+// Flags.Validate at parse time (exit 2, naming the accepted values) before any
+// kubeconfig load or listener bind — so it needs no apiserver.
+func TestRun_FluxIntegration_InvalidWebhookCertModeFailsWithExit2(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	sigs := make(chan os.Signal, 1)
 	withRestoredSlogDefault(t)
 	code := run([]string{
-		"--listen-address=127.0.0.1",
-		"--port=" + freePort(t),
-		"--management-listen-address=127.0.0.1",
-		"--management-port=" + freePort(t),
-		"--shutdown-delay=0",
 		"--enable-flux-integration",
 		"--enable-webhook",
 		"--webhook-cert-mode=bogus",
-		"--kubeconfig=" + kubeconfig,
 		"--storage-path=" + t.TempDir(),
 		"--storage-base-url=http://example.test/artifacts",
-		"--leader-election-namespace=default",
-		"--metrics-bind-address=0",
 	}, nil, &stdout, &stderr, sigs)
-	if code != 1 {
-		t.Fatalf("exit code = %d, want 1; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2; stderr=%q stdout=%q", code, stderr.String(), stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "Invalid --webhook-cert-mode") {
+	if !strings.Contains(stderr.String(), "webhook-cert-mode") {
 		t.Errorf("stderr = %q, want it to name the invalid --webhook-cert-mode", stderr.String())
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1620,7 +1620,7 @@ func TestRun_FluxIntegration_BadStoragePathReturnsOne(t *testing.T) {
 	}
 }
 
-func TestRun_FluxIntegration_UnknownBackendReturnsOne(t *testing.T) {
+func TestRun_FluxIntegration_UnknownBackendReturnsTwo(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	sigs := make(chan os.Signal, 1)
 	withRestoredSlogDefault(t)
@@ -1629,8 +1629,10 @@ func TestRun_FluxIntegration_UnknownBackendReturnsOne(t *testing.T) {
 		"--storage-base-url=http://x",
 		"--storage-backend=disk",
 	}, nil, &stdout, &stderr, sigs)
-	if code != 1 {
-		t.Errorf("exit code = %d, want 1", code)
+	// An out-of-set enum is a usage error caught by Flags.Validate at parse
+	// time (exit 2), not a runtime failure (exit 1).
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
 	}
 	if !strings.Contains(stderr.String(), "storage-backend") {
 		t.Errorf("stderr = %q, want it to mention storage-backend", stderr.String())


### PR DESCRIPTION
Validate() checked ports, durations, and bind addresses but let the enum-valued flags through: --log-level / --log-format fell back silently on a typo, and --webhook-cert-mode / --storage-backend only failed deep in startup. --tracing-sample-ratio was likewise unbounded. Validate now rejects an out-of-set enum and an out-of-range sample-ratio as a clean exit-2 usage error, matching the comprehensive Validate() in stageset-controller.