### PR TITLE
test(smoke): probe storage by ClusterIP in the netpol enforcement sce…

### DIFF
--- a/hack/smoke/lib.sh
+++ b/hack/smoke/lib.sh
@@ -107,6 +107,33 @@ ea_url() {
   kubectl -n "$2" get externalartifact "$1" -o jsonpath='{.status.artifact.url}' 2>/dev/null || true
 }
 
+# cluster_ip_url <url> — rewrite an in-cluster storage URL
+# (http://<svc>.<ns>.svc.cluster.local:<port>/<path>) to hit the Service's
+# ClusterIP directly, keeping the port and path. The NetworkPolicy enforcement
+# probe is about L3/L4 reachability to the storage pod, not name resolution;
+# probing by IP keeps a cluster-DNS hiccup — or a baseline egress policy that
+# doesn't admit DNS to kube-dns (the clusterNetworkPolicy engine renders
+# cluster-scoped policy that reaches the probe pod's namespace) — from
+# masquerading as a policy result. The destination pod's ingress policy still
+# governs the dial, so allow/deny semantics are unchanged. An IPv6 ClusterIP is
+# bracketed for curl.
+cluster_ip_url() {
+  local url=$1 rest hostport host port path svc ns ip
+  rest=${url#*://}
+  hostport=${rest%%/*}
+  path=${rest#"$hostport"}
+  port=${hostport##*:}
+  host=${hostport%:*}
+  svc=${host%%.*}
+  ns=${host#*.}; ns=${ns%%.*}
+  ip="$(kubectl -n "$ns" get svc "$svc" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+  if [ -z "$ip" ] || [ "$ip" = "None" ]; then
+    die "cannot resolve ClusterIP for service $ns/$svc (from URL $url)"
+  fi
+  case "$ip" in *:*) ip="[$ip]" ;; esac
+  printf 'http://%s:%s%s\n' "$ip" "$port" "$path"
+}
+
 # fetch_artifact <url> [grep_pattern] [namespace] — fetch the artifact tarball
 # from a throwaway in-cluster curl pod. With grep_pattern set, also untars and
 # asserts the pattern appears in the rendered output (the Publisher writes

--- a/hack/smoke/scenario-networkpolicy-enforcement.sh
+++ b/hack/smoke/scenario-networkpolicy-enforcement.sh
@@ -58,11 +58,17 @@ log "ALLOW: the artifact must be reachable on the storage port from an admitted 
 URL="$(ea_url "$NAME" "$NS")"
 [ -n "$URL" ] || die "snippet $NAME published no ExternalArtifact URL"
 log "ExternalArtifact URL: $URL"
-fetch_artifact "$URL" '"networkPolicy": "enforced"' flux-system
+# Probe by the storage Service's ClusterIP, not its DNS name: this scenario
+# asserts L3/L4 policy enforcement, so a probe-pod DNS failure (e.g. under the
+# clusterNetworkPolicy engine's cluster-scoped baseline egress) must not be
+# mistaken for a policy result.
+PROBE_URL="$(cluster_ip_url "$URL")"
+log "probing storage via ClusterIP: $PROBE_URL"
+fetch_artifact "$PROBE_URL" '"networkPolicy": "enforced"' flux-system
 
 if [ "$ENFORCE" = "1" ]; then
   log "DENY: the storage port must be BLOCKED from a non-admitted namespace ($NS)"
-  fetch_artifact_denied "$URL" "$NS"
+  fetch_artifact_denied "$PROBE_URL" "$NS"
 else
   log "ENFORCE=0: skipping the deny assertion (dialect is allow-all on the ports, or has no on-kind enforcer)"
 fi


### PR DESCRIPTION
…nario

The NetworkPolicy enforcement scenario curled the storage Service's DNS name from an ad-hoc probe pod. Under the clusterNetworkPolicy engine — which renders cluster-scoped policy reaching the probe pod's namespace — a probe-pod DNS failure (egress to kube-dns not admitted) surfaced as 'could not resolve host', masquerading as a policy-enforcement failure even though the operator published the artifact correctly. The scenario asserts L3/L4 reachability to the storage pod, not name resolution, so it now resolves the Service ClusterIP in the harness (cluster_ip_url) and probes by IP for both the allow and deny checks; the destination pod's ingress policy still governs the dial, so the semantics are unchanged.