### PR TITLE
chore(renovate): drop dead git-cliff-config customManager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,16 +3,5 @@
   "extends": ["github>metio/renovate-config"],
   "git-submodules": {
     "enabled": true
-  },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/release\\.yml$/"],
-      "matchStrings": ["git-cliff-config/(?<currentDigest>[0-9a-f]{40})/"],
-      "currentValueTemplate": "main",
-      "depNameTemplate": "metio/git-cliff-config",
-      "packageNameTemplate": "https://github.com/metio/git-cliff-config",
-      "datasourceTemplate": "git-refs"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
The git-cliff --config-url SHA is no longer pinned in this repo's release.yml — release notes are rendered by the shared metio/ci/release-notes action, which holds the git-cliff-config SHA (bumped by Renovate in metio/ci and picked up here via the metio/ci/release-notes action pin). The regex customManager scoped to release.yml therefore matched nothing. Remove it; this leaves no customManagers, so drop the empty array.