### PR TITLE
refactor: use the Go 1.26 new(expr) builtin for pointers to values

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -114,8 +114,7 @@ func TestMutate_PatchError(t *testing.T) {
 
 func TestGetSnippet_RendersLastSyncTime(t *testing.T) {
 	snip := newSnippet("team-a", "dash", false, metav1.ConditionTrue, "Synced", "ok")
-	now := metav1.Now()
-	snip.Status.LastSyncTime = &now
+	snip.Status.LastSyncTime = new(metav1.Now())
 	cfg := Config{KubeClient: fakeClient(t, snip), RunbookBaseURL: testRunbookBase}
 	_, out, err := cfg.getSnippetHandler(context.Background(), nil, getSnippetInput{Namespace: "team-a", Name: "dash"})
 	if err != nil {

--- a/internal/operator/envtest_run_test.go
+++ b/internal/operator/envtest_run_test.go
@@ -350,8 +350,7 @@ func runManagerInBackgroundWithBuilder(t *testing.T, restCfg *rest.Config, cfg C
 	done := make(chan error, 1)
 	build := func(restCfg *rest.Config, opts ctrl.Options, c Config) (runner, error) {
 		if c.SkipControllerNameValidation {
-			skip := true
-			opts.Controller = ctrlconfig.Controller{SkipNameValidation: &skip}
+			opts.Controller = ctrlconfig.Controller{SkipNameValidation: new(true)}
 		}
 		mgr, err := ctrl.NewManager(restCfg, opts)
 		if err != nil {
@@ -447,8 +446,7 @@ func runManagerInBackgroundWithReconcilerCapture(t *testing.T, restCfg *rest.Con
 	done := make(chan error, 1)
 	build := func(restCfg *rest.Config, opts ctrl.Options, c Config) (runner, error) {
 		if c.SkipControllerNameValidation {
-			skip := true
-			opts.Controller = ctrlconfig.Controller{SkipNameValidation: &skip}
+			opts.Controller = ctrlconfig.Controller{SkipNameValidation: new(true)}
 		}
 		mgr, err := ctrl.NewManager(restCfg, opts)
 		if err != nil {

--- a/internal/operator/envtest_webhook_test.go
+++ b/internal/operator/envtest_webhook_test.go
@@ -38,22 +38,19 @@ func TestEnvtest_Webhook_AdmissionRejectsExtVarConflict(t *testing.T) {
 		t.Fatalf("resolve CRD dir: %v", err)
 	}
 
-	failurePolicy := admissionregv1.Fail
-	sideEffects := admissionregv1.SideEffectClassNone
-	scope := admissionregv1.NamespacedScope
 	webhookConfig := &admissionregv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "jaas-webhook-test"},
 		Webhooks: []admissionregv1.ValidatingWebhook{
 			{
 				Name:                    "vjsonnetsnippet.jaas.metio.wtf",
-				FailurePolicy:           &failurePolicy,
-				SideEffects:             &sideEffects,
+				FailurePolicy:           new(admissionregv1.Fail),
+				SideEffects:             new(admissionregv1.SideEffectClassNone),
 				AdmissionReviewVersions: []string{"v1"},
 				ClientConfig: admissionregv1.WebhookClientConfig{
 					Service: &admissionregv1.ServiceReference{
 						Name:      "jaas-webhook",
 						Namespace: "default",
-						Path:      stringPtr("/validate-jaas-metio-wtf-v1-jsonnetsnippet"),
+						Path:      new("/validate-jaas-metio-wtf-v1-jsonnetsnippet"),
 					},
 				},
 				Rules: []admissionregv1.RuleWithOperations{
@@ -66,7 +63,7 @@ func TestEnvtest_Webhook_AdmissionRejectsExtVarConflict(t *testing.T) {
 							APIGroups:   []string{"jaas.metio.wtf"},
 							APIVersions: []string{"v1"},
 							Resources:   []string{"jsonnetsnippets"},
-							Scope:       &scope,
+							Scope:       new(admissionregv1.NamespacedScope),
 						},
 					},
 				},
@@ -227,5 +224,3 @@ func waitForWebhookReady(t *testing.T, c client.Client) {
 	}
 	t.Fatal("webhook server did not become ready within 15s")
 }
-
-func stringPtr(s string) *string { return &s }

--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -57,8 +57,7 @@ func (r *readinessSignal) Start(ctx context.Context) error {
 
 var defaultBuilder builder = func(restCfg *rest.Config, opts ctrl.Options, cfg Config) (runner, error) {
 	if cfg.SkipControllerNameValidation {
-		skip := true
-		opts.Controller = ctrlconfig.Controller{SkipNameValidation: &skip}
+		opts.Controller = ctrlconfig.Controller{SkipNameValidation: new(true)}
 	}
 	if cfg.EnableWebhook {
 		port := cfg.WebhookPort

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -1476,8 +1476,7 @@ func (r *SnippetReconciler) failReady(ctx context.Context, snip *jaasv1.JsonnetS
 	// prev as already-equal and suppresses the event.
 	var prev *metav1.Condition
 	if cur := apimeta.FindStatusCondition(snip.Status.Conditions, jaasv1.ConditionReady); cur != nil {
-		snapshot := *cur
-		prev = &snapshot
+		prev = new(*cur)
 	}
 	decorated := r.decorateMessage(reason, message)
 	helper, err := fluxpatch.NewHelper(snip, r.Client)
@@ -1581,7 +1580,6 @@ func (r *SnippetReconciler) markSynced(ctx context.Context, snip *jaasv1.Jsonnet
 	msg := fmt.Sprintf("Rendered %d bytes from %d files", len(rendered), sourceFileCount)
 	history := snip.Spec.History
 	now := r.now()
-	syncTime := metav1.NewTime(now)
 	key := types.NamespacedName{Name: snip.Name, Namespace: snip.Namespace}
 
 	// Staleness gate: a re-read confirms the spec we rendered is still
@@ -1633,7 +1631,7 @@ func (r *SnippetReconciler) markSynced(ctx context.Context, snip *jaasv1.Jsonnet
 		latest.Status.ArtifactURL = artifactURL
 	}
 	latest.Status.ObservedGeneration = latest.Generation
-	latest.Status.LastSyncTime = &syncTime
+	latest.Status.LastSyncTime = new(metav1.NewTime(now))
 	// Record that this reconcile handled the current
 	// reconcile.fluxcd.io/requestedAt token so `flux reconcile` can detect
 	// completion. The ReconcileRequestedPredicate fired on this token, so the

--- a/internal/operator/reconciler_test.go
+++ b/internal/operator/reconciler_test.go
@@ -151,8 +151,7 @@ func TestReconcile_AddsFinalizerOnFirstReconcile(t *testing.T) {
 
 func TestReconcile_DeletionTimestampWithFinalizerRemovesIt(t *testing.T) {
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -173,8 +172,7 @@ func TestReconcile_Delete_WithoutEffectiveSA_SkipsTokenCacheForget(t *testing.T)
 	// the "effective SA empty" branch.
 	snip := sampleSnippet()
 	snip.Spec.ServiceAccountName = ""
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -188,8 +186,7 @@ func TestReconcile_DeletionTimestampWithoutOurFinalizerIsNoOp(t *testing.T) {
 	// Another controller's finalizer keeps the object alive; ours is absent.
 	// We must not error and must leave the foreign finalizer untouched.
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{"some-other-controller/finalizer"}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -781,8 +778,7 @@ func TestReconcile_StatusUpdateErrorPropagates(t *testing.T) {
 
 func TestReconcile_DeleteUpdateErrorPropagates(t *testing.T) {
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	want := errors.New("conflict on finalizer drop")
 	c := fake.NewClientBuilder().
@@ -1122,8 +1118,7 @@ func TestReconcile_DeletionWithPublisher_WithdrawSucceeds(t *testing.T) {
 func TestReconcile_DeletionWithdrawErrorRequeues(t *testing.T) {
 	snip := sampleSnippet()
 	snip.Finalizers = []string{FinalizerName}
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 
 	want := errors.New("delete denied")
 	c := fake.NewClientBuilder().
@@ -1167,8 +1162,7 @@ func TestReconcileDelete_ErrorPathStillForgetsCycleVerdict(t *testing.T) {
 	snip := sampleSnippet()
 	snip.UID = types.UID("uid-delete-err")
 	snip.Finalizers = []string{FinalizerName}
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 
 	c := fake.NewClientBuilder().
 		WithScheme(publisherScheme(t)).
@@ -2213,8 +2207,7 @@ func TestReconcile_CycleDetectionTransientErrorWritesStatusAndRequeues(t *testin
 
 func TestReconcile_TenantClientErrorOnDeletePropagates(t *testing.T) {
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -2823,8 +2816,7 @@ func TestIsLastSnippetUsingSA(t *testing.T) {
 			Spec:       jaasv1.JsonnetSnippetSpec{ServiceAccountName: sa},
 		}
 		if deleting {
-			now := metav1.Now()
-			s.DeletionTimestamp = &now
+			s.DeletionTimestamp = new(metav1.Now())
 			s.Finalizers = []string{"keep"} // fake client rejects a deleting object without a finalizer
 		}
 		return s

--- a/internal/operator/token.go
+++ b/internal/operator/token.go
@@ -48,10 +48,9 @@ func (m clientsetTokenMinter) Mint(ctx context.Context, namespace, serviceAccoun
 	if m.kc == nil {
 		return "", time.Time{}, errors.New("tokenMinter: nil Kubernetes clientset")
 	}
-	secs := int64(ttl.Seconds())
 	out, err := m.kc.CoreV1().ServiceAccounts(namespace).CreateToken(ctx, serviceAccount,
 		&authnv1.TokenRequest{
-			Spec: authnv1.TokenRequestSpec{ExpirationSeconds: &secs},
+			Spec: authnv1.TokenRequestSpec{ExpirationSeconds: new(int64(ttl.Seconds()))},
 		}, metav1.CreateOptions{})
 	if err != nil {
 		return "", time.Time{}, err

--- a/internal/operator/webhook_test.go
+++ b/internal/operator/webhook_test.go
@@ -110,10 +110,9 @@ func TestSnippetValidator_ValidateUpdateChecksNewObj(t *testing.T) {
 // finalizer-removal update is blocked and the snippet wedges in Terminating.
 func TestSnippetValidator_ValidateUpdateSkipsObjectsUnderDeletion(t *testing.T) {
 	v := &SnippetValidator{OperatorExtVars: map[string]string{"cluster": "x"}}
-	now := metav1.Now()
 	snip := &jaasv1.JsonnetSnippet{
 		ObjectMeta: metav1.ObjectMeta{
-			DeletionTimestamp: &now,
+			DeletionTimestamp: new(metav1.Now()),
 			Finalizers:        []string{FinalizerName},
 		},
 		Spec: jaasv1.JsonnetSnippetSpec{

--- a/internal/webhook/selfsigned/envtest_test.go
+++ b/internal/webhook/selfsigned/envtest_test.go
@@ -41,16 +41,14 @@ func TestEnvtest_SelfSignedFlow_PatchesVWCEndToEnd(t *testing.T) {
 	}
 	vwcs := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 
-	failurePolicy := admissionv1.Fail
-	sideEffects := admissionv1.SideEffectClassNone
 	vwc := &admissionv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-selfsigned"},
 		Webhooks: []admissionv1.ValidatingWebhook{
 			{
 				Name:                    "vtest.example.com",
 				AdmissionReviewVersions: []string{"v1"},
-				FailurePolicy:           &failurePolicy,
-				SideEffects:             &sideEffects,
+				FailurePolicy:           new(admissionv1.Fail),
+				SideEffects:             new(admissionv1.SideEffectClassNone),
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
 						Name:      "jaas-webhook",
@@ -153,16 +151,14 @@ func TestEnvtest_SelfSignedFlow_RotateRePatchesVWC(t *testing.T) {
 	}
 	vwcs := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 
-	failurePolicy := admissionv1.Fail
-	sideEffects := admissionv1.SideEffectClassNone
 	vwc := &admissionv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-rotate"},
 		Webhooks: []admissionv1.ValidatingWebhook{
 			{
 				Name:                    "vrotate.example.com",
 				AdmissionReviewVersions: []string{"v1"},
-				FailurePolicy:           &failurePolicy,
-				SideEffects:             &sideEffects,
+				FailurePolicy:           new(admissionv1.Fail),
+				SideEffects:             new(admissionv1.SideEffectClassNone),
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{Name: "x", Namespace: "default"},
 				},


### PR DESCRIPTION
Go 1.26's new builtin accepts an expression and returns a pointer to a fresh variable holding that value, replacing the &tmp / pointer-helper pattern. Apply it where a pointer to a literal or computed value is needed (controller-runtime SkipNameValidation, TokenRequest ExpirationSeconds, and test fixtures), and drop the now-unused stringPtr helper.