### PR TITLE
refactor: adopt newer-Go idioms via modernize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ ilo bash -c 'staticcheck ./...'                    # CI: staticcheck (checks=all
 ilo bash -c 'gofumpt -l .'                         # CI: strict formatting (empty output == clean)
 ilo bash -c 'gosec ./...'                          # CI: security scanner
 ilo bash -c 'arch-go'                              # CI: architecture rules (arch-go.yml)
+ilo bash -c 'modernize ./...'                      # CI: newer-Go idiom check (ignore zz_generated.deepcopy.go maps.Copy hits)
 ilo bash -c 'go test -count=1 -race -cover ./...'  # full suite with race detector
 ilo bash -c 'go test -count=1 -v -run TestName ./internal/handler/'  # single test
 ilo bash -c 'go test -bench=BenchmarkReconcile -benchmem -run=^$ ./internal/operator/'  # reconciler throughput baseline

--- a/dev/Containerfile
+++ b/dev/Containerfile
@@ -48,6 +48,9 @@ RUN go install github.com/securego/gosec/v2/cmd/gosec@latest
 RUN go install github.com/arch-go/arch-go@latest
 RUN go install github.com/rhysd/actionlint/cmd/actionlint@latest
 RUN go install golang.org/x/vuln/cmd/govulncheck@latest
+# modernize: flags code that can adopt newer-Go idioms (the CI lint gate). It
+# also reports the generated zz_generated.deepcopy.go (maps.Copy); ignore those.
+RUN go install golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
 
 # envtest assets for the controller tests. controller-gen is NOT installed here:
 # it's a go.mod `tool` directive, run via `go tool controller-gen` (one pinned

--- a/internal/eval/importer.go
+++ b/internal/eval/importer.go
@@ -121,7 +121,7 @@ func (im *InMemoryImporter) resolve(importedFrom, importedPath string) (string, 
 		}
 	}
 
-	if i := strings.IndexByte(importedPath, '/'); i < 0 {
+	if before, after, ok := strings.Cut(importedPath, "/"); !ok {
 		// 2. Bare name: a registered library's default entry.
 		if lib, ok := im.Libraries[importedPath]; ok {
 			body, ok := lib.Files[defaultLibraryEntryFile]
@@ -132,8 +132,8 @@ func (im *InMemoryImporter) resolve(importedFrom, importedPath string) (string, 
 		}
 	} else {
 		// 3. Explicit alias/file: authoritative when the head is a registered alias.
-		alias := importedPath[:i]
-		fileWithin := path.Clean(importedPath[i+1:])
+		alias := before
+		fileWithin := path.Clean(after)
 		if lib, ok := im.Libraries[alias]; ok {
 			body, ok := lib.Files[fileWithin]
 			if !ok {

--- a/internal/eval/importer_test.go
+++ b/internal/eval/importer_test.go
@@ -181,12 +181,10 @@ func TestInMemoryImporter_CacheIsConcurrencySafe(t *testing.T) {
 		},
 	}
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 50 {
+		wg.Go(func() {
 			_, _, _ = im.Import("", "utils")
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/eval/semaphore_test.go
+++ b/internal/eval/semaphore_test.go
@@ -33,7 +33,7 @@ func resetEvalSemaphore(t *testing.T) {
 
 func TestReserveEvalSlot_DisabledCapAlwaysAcquires(t *testing.T) {
 	resetEvalSemaphore(t)
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		release, ok := reserveEvalSlot()
 		if !ok {
 			t.Fatalf("iter %d: cap=0 should never reject", i)
@@ -92,10 +92,8 @@ func TestReserveEvalSlot_ConcurrentNeverExceedsCap(t *testing.T) {
 	var accepted atomic.Int64
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	for i := 0; i < burst; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range burst {
+		wg.Go(func() {
 			<-start
 			release, ok := reserveEvalSlot()
 			if !ok {
@@ -110,7 +108,7 @@ func TestReserveEvalSlot_ConcurrentNeverExceedsCap(t *testing.T) {
 				}
 			}
 			release()
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()
@@ -253,7 +251,7 @@ func TestSetMaxConcurrentEvals_NegativeIsTreatedAsZero(t *testing.T) {
 		t.Errorf("MaxConcurrentEvals after Set(-5) = %d, want 0", got)
 	}
 	// And with cap=0, the gate is disabled.
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		if _, ok := reserveEvalSlot(); !ok {
 			t.Fatalf("iter %d: negative cap must disable the gate", i)
 		}

--- a/internal/eval/tla_test.go
+++ b/internal/eval/tla_test.go
@@ -91,7 +91,7 @@ func TestApplyTLAs_ConcurrentEvalsAreIsolated(t *testing.T) {
 	const workers = 100
 	var wg sync.WaitGroup
 	errs := make(chan error, workers)
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/internal/handler/fuzz_test.go
+++ b/internal/handler/fuzz_test.go
@@ -71,12 +71,12 @@ func FuzzParseExtVars(f *testing.F) {
 		// and ParseExtVars surfaces as a failure.
 		want := map[string]string{}
 		for _, env := range environ {
-			eq := strings.IndexByte(env, '=')
-			if eq < 0 {
+			before, after, ok := strings.Cut(env, "=")
+			if !ok {
 				continue
 			}
-			key := env[:eq]
-			value := env[eq+1:]
+			key := before
+			value := after
 			if !strings.HasPrefix(key, extVarPrefix) {
 				continue
 			}

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -36,7 +36,7 @@ func TestHealthState_MarkStarted(t *testing.T) {
 
 func TestHealthState_MarkStartedIsIdempotent(t *testing.T) {
 	s := NewHealthState()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		s.MarkStarted()
 	}
 	if !s.Started() {
@@ -100,7 +100,7 @@ func TestHealthState_DrainingLatchBlocksSetReadyTrue(t *testing.T) {
 
 func TestHealthState_ReadyIsCycleable(t *testing.T) {
 	s := NewHealthState()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		s.SetReady(true)
 		if !s.Ready() {
 			t.Fatalf("iter %d: Ready() = false after SetReady(true)", i)
@@ -117,7 +117,7 @@ func TestHealthState_ConcurrentWritersAndReaders(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const goroutines = 100
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		wg.Add(3)
 		go func() {
 			defer wg.Done()
@@ -147,17 +147,15 @@ func TestHealthState_ManyConcurrentReads(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const readers = 1000
-	for i := 0; i < readers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range readers {
+		wg.Go(func() {
 			if !s.Started() {
 				t.Error("Started() = false in concurrent read")
 			}
 			if !s.Ready() {
 				t.Error("Ready() = false in concurrent read")
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -173,7 +171,7 @@ func TestLivenessHandler_GETReturns200WithJSONBody(t *testing.T) {
 
 func TestLivenessHandler_AlwaysReturns200(t *testing.T) {
 	h := LivenessHandler()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		rr := callProbe(t, h, http.MethodGet)
 		if rr.Code != http.StatusOK {
 			t.Errorf("call %d: status = %d, want 200", i, rr.Code)

--- a/internal/handler/jsonnet_test.go
+++ b/internal/handler/jsonnet_test.go
@@ -148,7 +148,7 @@ func TestParseExtVars_ReturnsNonNilOnEmpty(t *testing.T) {
 
 func TestParseExtVars_ManyEntries(t *testing.T) {
 	environ := make([]string, 0, 1000)
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		environ = append(environ, fmt.Sprintf("JAAS_EXT_VAR_k%d=v%d", i, i))
 		environ = append(environ, fmt.Sprintf("OTHER_%d=ignored", i))
 	}
@@ -156,7 +156,7 @@ func TestParseExtVars_ManyEntries(t *testing.T) {
 	if len(got) != 500 {
 		t.Fatalf("len(got) = %d, want 500", len(got))
 	}
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		key := fmt.Sprintf("k%d", i)
 		want := fmt.Sprintf("v%d", i)
 		if got[key] != want {
@@ -852,7 +852,7 @@ func TestJsonnetHandler_ExtVarsStableAcrossMultipleRequests(t *testing.T) {
 		ExtVars:            map[string]string{"v": "fixed"},
 	})
 
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		rr := callExtVarSnippet(t, h, "echo")
 		if rr.Code != http.StatusOK {
 			t.Fatalf("call %d: status = %d, want 200", i, rr.Code)
@@ -871,14 +871,14 @@ func TestJsonnetHandler_ExtVarsManyKeysAllExposed(t *testing.T) {
 
 	const N = 50
 	vars := make(map[string]string, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		vars[fmt.Sprintf("k%d", i)] = fmt.Sprintf("v%d", i)
 	}
 
 	// Build a snippet that emits {k0: extVar("k0"), k1: extVar("k1"), …}
 	var b strings.Builder
 	b.WriteString("{ ")
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if i > 0 {
 			b.WriteString(", ")
 		}
@@ -1064,10 +1064,8 @@ func TestJsonnetHandler_ConcurrentRequestsAreRaceFree(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const workers = 100
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range workers {
+		wg.Go(func() {
 			rr := callExtVarSnippet(t, h, "echo")
 			if rr.Code != http.StatusOK {
 				t.Errorf("status = %d, want 200", rr.Code)
@@ -1076,7 +1074,7 @@ func TestJsonnetHandler_ConcurrentRequestsAreRaceFree(t *testing.T) {
 			if !strings.Contains(rr.Body.String(), `"shared"`) {
 				t.Errorf("body = %q, want \"shared\"", rr.Body.String())
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -1115,10 +1113,8 @@ func TestJsonnetHandler_LibraryImport_RaceFreeUnderLoad(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const workers = 100
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range workers {
+		wg.Go(func() {
 			rr := callExtVarSnippet(t, h, "use")
 			if rr.Code != http.StatusOK {
 				t.Errorf("status = %d, want 200 (body: %s)", rr.Code, rr.Body.String())
@@ -1127,7 +1123,7 @@ func TestJsonnetHandler_LibraryImport_RaceFreeUnderLoad(t *testing.T) {
 			if !strings.Contains(rr.Body.String(), "race-free") {
 				t.Errorf("body = %q, want 'race-free'", rr.Body.String())
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -1638,10 +1634,8 @@ func TestJsonnetHandler_LibraryImport_HighConcurrencyStress(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const workers = 500
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range workers {
+		wg.Go(func() {
 			rr := callExtVarSnippet(t, h, "use")
 			if rr.Code != http.StatusOK {
 				t.Errorf("status = %d, want 200", rr.Code)
@@ -1650,7 +1644,7 @@ func TestJsonnetHandler_LibraryImport_HighConcurrencyStress(t *testing.T) {
 			if !strings.Contains(rr.Body.String(), "stress-ok") {
 				t.Errorf("body = %q, want 'stress-ok'", rr.Body.String())
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -1677,7 +1671,7 @@ func TestJsonnetHandler_LibraryImport_ConcurrentMixedSnippets(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for snippet, want := range cases {
-		for i := 0; i < 30; i++ {
+		for range 30 {
 			wg.Add(1)
 			go func(snippet, want string) {
 				defer wg.Done()
@@ -1711,7 +1705,7 @@ func TestJsonnetHandler_LibraryImport_ConcurrentWithExtVarsAndTLAs(t *testing.T)
 
 	var wg sync.WaitGroup
 	const workers = 50
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -1920,7 +1914,7 @@ func TestJsonnetHandler_Logger_PerHandlerIsolation(t *testing.T) {
 func TestJsonnetHandler_Logger_StableAcrossMultipleRequests(t *testing.T) {
 	cap := newRecordCapture()
 	h := JsonnetHandler(Config{Logger: slog.New(cap)})
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		req := httptest.NewRequest(http.MethodPost, "/jsonnet/x", nil)
 		rr := httptest.NewRecorder()
 		h(rr, req)
@@ -2266,13 +2260,11 @@ func TestJsonnetHandler_Logger_ConcurrentRequestsAllCaptured(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const workers = 100
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range workers {
+		wg.Go(func() {
 			rr := httptest.NewRecorder()
 			h(rr, httptest.NewRequest(http.MethodPost, "/jsonnet/x", nil))
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/mcp/render.go
+++ b/internal/mcp/render.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/google/go-jsonnet"
@@ -117,12 +118,8 @@ func (cfg Config) mergedExtVars(callExtVars map[string]string) map[string]string
 		return cfg.ExtVars
 	}
 	merged := make(map[string]string, len(cfg.ExtVars)+len(callExtVars))
-	for k, v := range cfg.ExtVars {
-		merged[k] = v
-	}
-	for k, v := range callExtVars {
-		merged[k] = v
-	}
+	maps.Copy(merged, cfg.ExtVars)
+	maps.Copy(merged, callExtVars)
 	return merged
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -114,8 +114,7 @@ func TestMutate_PatchError(t *testing.T) {
 
 func TestGetSnippet_RendersLastSyncTime(t *testing.T) {
 	snip := newSnippet("team-a", "dash", false, metav1.ConditionTrue, "Synced", "ok")
-	now := metav1.Now()
-	snip.Status.LastSyncTime = &now
+	snip.Status.LastSyncTime = new(metav1.Now())
 	cfg := Config{KubeClient: fakeClient(t, snip), RunbookBaseURL: testRunbookBase}
 	_, out, err := cfg.getSnippetHandler(context.Background(), nil, getSnippetInput{Namespace: "team-a", Name: "dash"})
 	if err != nil {

--- a/internal/operator/conditions_test.go
+++ b/internal/operator/conditions_test.go
@@ -56,17 +56,17 @@ func TestAllReasons_CoversEveryConstant(t *testing.T) {
 		t.Fatalf("read conditions.go: %v", err)
 	}
 	var declared []string
-	for _, line := range strings.Split(string(src), "\n") {
+	for line := range strings.SplitSeq(string(src), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "Reason") {
 			continue
 		}
 		// Match "ReasonName = \"...\"".
-		eq := strings.Index(line, "=")
-		if eq < 0 {
+		before, _, ok := strings.Cut(line, "=")
+		if !ok {
 			continue
 		}
-		declared = append(declared, strings.TrimSpace(line[:eq]))
+		declared = append(declared, strings.TrimSpace(before))
 	}
 	if len(declared) != len(AllReasons) {
 		t.Errorf("conditions.go declares %d Reason* constants but AllReasons has %d entries — keep them in sync.\n  declared: %v\n  AllReasons (len %d)", len(declared), len(AllReasons), declared, len(AllReasons))

--- a/internal/operator/config.go
+++ b/internal/operator/config.go
@@ -252,15 +252,15 @@ func ParseExtVars(pairs []string) (map[string]string, error) {
 	}
 	out := make(map[string]string, len(pairs))
 	for _, p := range pairs {
-		i := strings.IndexByte(p, '=')
-		if i < 0 {
+		before, after, ok := strings.Cut(p, "=")
+		if !ok {
 			return nil, fmt.Errorf("ext-var %q: missing '='", p)
 		}
-		k := p[:i]
+		k := before
 		if k == "" {
 			return nil, fmt.Errorf("ext-var %q: empty key", p)
 		}
-		out[k] = p[i+1:]
+		out[k] = after
 	}
 	return out, nil
 }

--- a/internal/operator/coverage_extra2_test.go
+++ b/internal/operator/coverage_extra2_test.go
@@ -306,10 +306,10 @@ func TestReconstructCyclePath_BrokenParentChain(t *testing.T) {
 // A non-map entry in status.conditions is skipped rather than crashing the
 // rebuild, and the Ready condition is still appended.
 func TestSetReadyCondition_SkipsMalformedConditionEntry(t *testing.T) {
-	ea := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	if err := unstructured.SetNestedSlice(ea.Object, []interface{}{
+	ea := &unstructured.Unstructured{Object: map[string]any{}}
+	if err := unstructured.SetNestedSlice(ea.Object, []any{
 		"not-a-map",
-		map[string]interface{}{"type": "Stalled", "status": "False"},
+		map[string]any{"type": "Stalled", "status": "False"},
 	}, "status", "conditions"); err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +319,7 @@ func TestSetReadyCondition_SkipsMalformedConditionEntry(t *testing.T) {
 	conds, _, _ := unstructured.NestedSlice(ea.Object, "status", "conditions")
 	var sawReady, sawStalled bool
 	for _, c := range conds {
-		m, ok := c.(map[string]interface{})
+		m, ok := c.(map[string]any)
 		if !ok {
 			t.Errorf("malformed entry survived the rebuild: %v", c)
 			continue
@@ -342,9 +342,9 @@ func TestSetReadyCondition_SkipsMalformedConditionEntry(t *testing.T) {
 // A fresh artifact with a Ready=False existing condition takes the supplied
 // now as its lastTransitionTime (the True-preservation branch is bypassed).
 func TestSetReadyCondition_NotPreviouslyTrueUsesNow(t *testing.T) {
-	ea := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	if err := unstructured.SetNestedSlice(ea.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False", "lastTransitionTime": "2020-01-01T00:00:00Z"},
+	ea := &unstructured.Unstructured{Object: map[string]any{}}
+	if err := unstructured.SetNestedSlice(ea.Object, []any{
+		map[string]any{"type": "Ready", "status": "False", "lastTransitionTime": "2020-01-01T00:00:00Z"},
 	}, "status", "conditions"); err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +355,7 @@ func TestSetReadyCondition_NotPreviouslyTrueUsesNow(t *testing.T) {
 	conds, _, _ := unstructured.NestedSlice(ea.Object, "status", "conditions")
 	var ltt string
 	for _, c := range conds {
-		m, _ := c.(map[string]interface{})
+		m, _ := c.(map[string]any)
 		if m["type"] == "Ready" {
 			ltt, _ = m["lastTransitionTime"].(string)
 		}

--- a/internal/operator/crdwatcher.go
+++ b/internal/operator/crdwatcher.go
@@ -39,7 +39,7 @@ var (
 // returns 2× that, etc.
 func crdWatchBackoff(attempt int) time.Duration {
 	d := crdWatchInitialDelay
-	for i := 0; i < attempt; i++ {
+	for range attempt {
 		d *= 2
 	}
 	return d
@@ -179,7 +179,7 @@ func (w *crdWatcher) Start(ctx context.Context) error {
 		attempts[gvk] = 0
 		stateMu.Unlock()
 	}
-	check := func(obj interface{}) {
+	check := func(obj any) {
 		gvk, ok := w.matchedCRD(obj)
 		if !ok {
 			return
@@ -197,8 +197,8 @@ func (w *crdWatcher) Start(ctx context.Context) error {
 		attempt(gvk)
 	}
 	if _, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { check(obj) },
-		UpdateFunc: func(_, obj interface{}) { check(obj) },
+		AddFunc:    func(obj any) { check(obj) },
+		UpdateFunc: func(_, obj any) { check(obj) },
 	}); err != nil {
 		return fmt.Errorf("crd watcher: add event handler: %w", err)
 	}
@@ -245,7 +245,7 @@ func (w *crdWatcher) degradeOnSyncFailure(ctx context.Context, logger *slog.Logg
 // whose name matches one of w.kinds AND whose status reports
 // Established=True. Pure function exported via the receiver so unit tests
 // can drive it directly without standing up a cache.
-func (w *crdWatcher) matchedCRD(obj interface{}) (schema.GroupVersionKind, bool) {
+func (w *crdWatcher) matchedCRD(obj any) (schema.GroupVersionKind, bool) {
 	crd, ok := obj.(*apiextv1.CustomResourceDefinition)
 	if !ok {
 		return schema.GroupVersionKind{}, false

--- a/internal/operator/cycle.go
+++ b/internal/operator/cycle.go
@@ -8,6 +8,8 @@ package operator
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -279,8 +281,8 @@ func reconstructCyclePath(parent map[types.NamespacedName]types.NamespacedName, 
 	}
 	out := make([]types.NamespacedName, 0, len(stack)+2)
 	out = append(out, start)
-	for i := len(stack) - 1; i >= 0; i-- {
-		out = append(out, stack[i])
+	for _, s := range slices.Backward(stack) {
+		out = append(out, s)
 	}
 	out = append(out, start)
 	return out
@@ -293,9 +295,10 @@ func formatCyclePath(path []types.NamespacedName) string {
 	if len(path) == 0 {
 		return ""
 	}
-	out := path[0].String()
+	var out strings.Builder
+	out.WriteString(path[0].String())
 	for _, p := range path[1:] {
-		out += " → " + p.String()
+		out.WriteString(" → " + p.String())
 	}
-	return out
+	return out.String()
 }

--- a/internal/operator/envtest_disaster_recovery_test.go
+++ b/internal/operator/envtest_disaster_recovery_test.go
@@ -147,7 +147,7 @@ func bumpReconcileAnnotation(t *testing.T, c client.Client, key types.Namespaced
 func externalArtifactReady(ea *unstructured.Unstructured) bool {
 	conds, _, _ := unstructured.NestedSlice(ea.Object, "status", "conditions")
 	for _, c := range conds {
-		m, ok := c.(map[string]interface{})
+		m, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/internal/operator/envtest_reconcile_test.go
+++ b/internal/operator/envtest_reconcile_test.go
@@ -53,7 +53,7 @@ func directReconciler(t *testing.T, c client.Client, withPublisher bool) *Snippe
 // manager's watch-driven reconcile loop.
 func driveToReady(t *testing.T, r *SnippetReconciler, c client.Client, key types.NamespacedName, wantStatus metav1.ConditionStatus, wantReason string, maxRounds int) {
 	t.Helper()
-	for i := 0; i < maxRounds; i++ {
+	for range maxRounds {
 		// Reconcile may return an error on TRANSIENT classifications
 		// (source-not-ready, network blip) — controller-runtime would
 		// engage backoff and retry. The status is still written
@@ -256,7 +256,7 @@ func TestEnvtest_Reconcile_BulkDelete_AllFinalizersFire(t *testing.T) {
 
 	const n = 5
 	keys := make([]types.NamespacedName, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		snip := &jaasv1.JsonnetSnippet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bulk-" + strconv.Itoa(i),

--- a/internal/operator/envtest_run_test.go
+++ b/internal/operator/envtest_run_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -350,8 +351,7 @@ func runManagerInBackgroundWithBuilder(t *testing.T, restCfg *rest.Config, cfg C
 	done := make(chan error, 1)
 	build := func(restCfg *rest.Config, opts ctrl.Options, c Config) (runner, error) {
 		if c.SkipControllerNameValidation {
-			skip := true
-			opts.Controller = ctrlconfig.Controller{SkipNameValidation: &skip}
+			opts.Controller = ctrlconfig.Controller{SkipNameValidation: new(true)}
 		}
 		mgr, err := ctrl.NewManager(restCfg, opts)
 		if err != nil {
@@ -447,8 +447,7 @@ func runManagerInBackgroundWithReconcilerCapture(t *testing.T, restCfg *rest.Con
 	done := make(chan error, 1)
 	build := func(restCfg *rest.Config, opts ctrl.Options, c Config) (runner, error) {
 		if c.SkipControllerNameValidation {
-			skip := true
-			opts.Controller = ctrlconfig.Controller{SkipNameValidation: &skip}
+			opts.Controller = ctrlconfig.Controller{SkipNameValidation: new(true)}
 		}
 		mgr, err := ctrl.NewManager(restCfg, opts)
 		if err != nil {
@@ -554,7 +553,7 @@ func TestEnvtest_CRDWatch_LateInstallEngagesWatchLive(t *testing.T) {
 		// registers Watches(Bucket) against a stale-but-present CRD and
 		// the informer's LIST never reports synced, blocking
 		// WaitForCacheSync indefinitely.
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			var got apiextv1.CustomResourceDefinition
 			if err := c.Get(context.Background(), client.ObjectKeyFromObject(bucket), &got); err != nil {
 				return
@@ -600,12 +599,7 @@ func TestEnvtest_CRDWatch_LateInstallEngagesWatchLive(t *testing.T) {
 }
 
 func contains(haystack []schema.GroupVersionKind, needle schema.GroupVersionKind) bool {
-	for _, g := range haystack {
-		if g == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }
 
 // TestEnvtest_Watch_FluxSourceUpdate_IndirectViaLibrary proves that updating

--- a/internal/operator/envtest_webhook_test.go
+++ b/internal/operator/envtest_webhook_test.go
@@ -38,22 +38,19 @@ func TestEnvtest_Webhook_AdmissionRejectsExtVarConflict(t *testing.T) {
 		t.Fatalf("resolve CRD dir: %v", err)
 	}
 
-	failurePolicy := admissionregv1.Fail
-	sideEffects := admissionregv1.SideEffectClassNone
-	scope := admissionregv1.NamespacedScope
 	webhookConfig := &admissionregv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "jaas-webhook-test"},
 		Webhooks: []admissionregv1.ValidatingWebhook{
 			{
 				Name:                    "vjsonnetsnippet.jaas.metio.wtf",
-				FailurePolicy:           &failurePolicy,
-				SideEffects:             &sideEffects,
+				FailurePolicy:           new(admissionregv1.Fail),
+				SideEffects:             new(admissionregv1.SideEffectClassNone),
 				AdmissionReviewVersions: []string{"v1"},
 				ClientConfig: admissionregv1.WebhookClientConfig{
 					Service: &admissionregv1.ServiceReference{
 						Name:      "jaas-webhook",
 						Namespace: "default",
-						Path:      stringPtr("/validate-jaas-metio-wtf-v1-jsonnetsnippet"),
+						Path:      new("/validate-jaas-metio-wtf-v1-jsonnetsnippet"),
 					},
 				},
 				Rules: []admissionregv1.RuleWithOperations{
@@ -66,7 +63,7 @@ func TestEnvtest_Webhook_AdmissionRejectsExtVarConflict(t *testing.T) {
 							APIGroups:   []string{"jaas.metio.wtf"},
 							APIVersions: []string{"v1"},
 							Resources:   []string{"jsonnetsnippets"},
-							Scope:       &scope,
+							Scope:       new(admissionregv1.NamespacedScope),
 						},
 					},
 				},
@@ -227,5 +224,3 @@ func waitForWebhookReady(t *testing.T, c client.Client) {
 	}
 	t.Fatal("webhook server did not become ready within 15s")
 }
-
-func stringPtr(s string) *string { return &s }

--- a/internal/operator/history_property_test.go
+++ b/internal/operator/history_property_test.go
@@ -81,10 +81,7 @@ func TestUpdateRevisionHistory_Property(t *testing.T) {
 		out := updateRevisionHistory(prior, revision, historyMax, now)
 
 		// Invariant 1: length cap.
-		cap := int(historyMax)
-		if cap < 1 {
-			cap = 1
-		}
+		cap := max(int(historyMax), 1)
 		if len(out) > cap {
 			t.Errorf("len(out)=%d exceeds cap %d (historyMax=%d)", len(out), cap, historyMax)
 		}
@@ -96,14 +93,11 @@ func TestUpdateRevisionHistory_Property(t *testing.T) {
 		if sameHead {
 			// Invariant 2 + 4: output is prior truncated to cap;
 			// the head's timestamp is preserved.
-			wantLen := len(prior)
-			if wantLen > cap {
-				wantLen = cap
-			}
+			wantLen := min(len(prior), cap)
 			if len(out) != wantLen {
 				t.Errorf("same-head: len(out)=%d, want %d", len(out), wantLen)
 			}
-			for i := 0; i < len(out); i++ {
+			for i := range out {
 				if out[i].Revision != prior[i].Revision {
 					t.Errorf("same-head out[%d].Revision = %q, want %q",
 						i, out[i].Revision, prior[i].Revision)
@@ -178,10 +172,7 @@ func TestBuildKeepShortRevs_Property(t *testing.T) {
 		out := buildKeepShortRevs(newRev, prior, history)
 
 		// Invariant 1: length cap.
-		cap := int(history)
-		if cap < 1 {
-			cap = 1
-		}
+		cap := max(int(history), 1)
 		if len(out) > cap {
 			t.Errorf("len(out)=%d exceeds cap %d (history=%d)", len(out), cap, history)
 		}

--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -57,8 +57,7 @@ func (r *readinessSignal) Start(ctx context.Context) error {
 
 var defaultBuilder builder = func(restCfg *rest.Config, opts ctrl.Options, cfg Config) (runner, error) {
 	if cfg.SkipControllerNameValidation {
-		skip := true
-		opts.Controller = ctrlconfig.Controller{SkipNameValidation: &skip}
+		opts.Controller = ctrlconfig.Controller{SkipNameValidation: new(true)}
 	}
 	if cfg.EnableWebhook {
 		port := cfg.WebhookPort

--- a/internal/operator/manager_test.go
+++ b/internal/operator/manager_test.go
@@ -122,8 +122,7 @@ func TestRunWithBuilder_PassesSchemeAndContext(t *testing.T) {
 		seenCfg = cfg
 		return fake, nil
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	cfg := Config{

--- a/internal/operator/publisher.go
+++ b/internal/operator/publisher.go
@@ -298,8 +298,8 @@ func (p *Publisher) upsertExternalArtifact(ctx context.Context, c client.Client,
 // shape and the byte-for-byte tarball stable across re-publishes of
 // other revisions.
 func setSpec(ea *unstructured.Unstructured, snip *jaasv1.JsonnetSnippet) error {
-	return unstructured.SetNestedMap(ea.Object, map[string]interface{}{
-		"sourceRef": map[string]interface{}{
+	return unstructured.SetNestedMap(ea.Object, map[string]any{
+		"sourceRef": map[string]any{
 			"apiVersion": jaasv1.GroupVersion.String(),
 			"kind":       "JsonnetSnippet",
 			"name":       snip.Name,
@@ -309,7 +309,7 @@ func setSpec(ea *unstructured.Unstructured, snip *jaasv1.JsonnetSnippet) error {
 
 func (p *Publisher) writeStatus(ctx context.Context, c client.Client, ea *unstructured.Unstructured, revision string, res storage.Result) error {
 	now := p.now().UTC().Format(time.RFC3339)
-	artifact := map[string]interface{}{
+	artifact := map[string]any{
 		"url":            p.url(res.Path),
 		"path":           res.Path,
 		"revision":       revision,
@@ -361,9 +361,9 @@ func setReadyCondition(latest *unstructured.Unstructured, now string) {
 	// co-managing Flux controller stamps on the ExternalArtifact (Reconciling,
 	// Stalled, …); the artifact's conditions are a set keyed by type, and this
 	// owns only Ready.
-	conditions := make([]interface{}, 0, len(existing)+1)
+	conditions := make([]any, 0, len(existing)+1)
 	for _, c := range existing {
-		m, ok := c.(map[string]interface{})
+		m, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -377,7 +377,7 @@ func setReadyCondition(latest *unstructured.Unstructured, now string) {
 			}
 		}
 	}
-	ready := map[string]interface{}{
+	ready := map[string]any{
 		"type":               "Ready",
 		"status":             "True",
 		"reason":             "Succeeded",

--- a/internal/operator/publisher_test.go
+++ b/internal/operator/publisher_test.go
@@ -128,14 +128,14 @@ func TestPublish_RenderedMode_WritesArtifactAndStatus(t *testing.T) {
 
 // readyConditionOf returns the Ready condition map from an EA's
 // status.conditions, or nil if absent.
-func readyConditionOf(t *testing.T, ea *unstructured.Unstructured) map[string]interface{} {
+func readyConditionOf(t *testing.T, ea *unstructured.Unstructured) map[string]any {
 	t.Helper()
 	conds, _, err := unstructured.NestedSlice(ea.Object, "status", "conditions")
 	if err != nil {
 		t.Fatalf("status.conditions malformed: %v", err)
 	}
 	for _, c := range conds {
-		m, ok := c.(map[string]interface{})
+		m, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -214,10 +214,10 @@ func TestPublish_ReadyConditionPreservesLastTransitionTime(t *testing.T) {
 // keeps any non-Ready condition a co-managing controller put on the artifact —
 // the conditions are a set keyed by type, and the publisher owns only Ready.
 func TestSetReadyCondition_PreservesForeignConditions(t *testing.T) {
-	ea := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	if err := unstructured.SetNestedSlice(ea.Object, []interface{}{
-		map[string]interface{}{"type": "Stalled", "status": "False", "reason": "Healthy"},
-		map[string]interface{}{"type": "Ready", "status": "True", "lastTransitionTime": "2020-01-01T00:00:00Z"},
+	ea := &unstructured.Unstructured{Object: map[string]any{}}
+	if err := unstructured.SetNestedSlice(ea.Object, []any{
+		map[string]any{"type": "Stalled", "status": "False", "reason": "Healthy"},
+		map[string]any{"type": "Ready", "status": "True", "lastTransitionTime": "2020-01-01T00:00:00Z"},
 	}, "status", "conditions"); err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +228,7 @@ func TestSetReadyCondition_PreservesForeignConditions(t *testing.T) {
 	var sawStalled, sawReady bool
 	var readyLTT string
 	for _, c := range conds {
-		m, _ := c.(map[string]interface{})
+		m, _ := c.(map[string]any)
 		switch m["type"] {
 		case "Stalled":
 			sawStalled = true

--- a/internal/operator/ratelimiter_test.go
+++ b/internal/operator/ratelimiter_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRateLimiter_NilReceiverAlwaysAllows(t *testing.T) {
 	var l *RateLimiter
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if ok, _ := l.Reserve("any"); !ok {
 			t.Errorf("nil limiter denied iter %d", i)
 		}
@@ -21,7 +21,7 @@ func TestRateLimiter_NilReceiverAlwaysAllows(t *testing.T) {
 
 func TestRateLimiter_AllowsUpToBurst(t *testing.T) {
 	l := NewRateLimiter(1.0, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if ok, _ := l.Reserve("k"); !ok {
 			t.Errorf("Reserve %d denied within burst", i)
 		}
@@ -64,7 +64,7 @@ func TestRateLimiter_RejectionDoesNotDrainFutureTokens(t *testing.T) {
 
 func TestRateLimiter_ZeroOrNegativeRateFallsBackToPermissive(t *testing.T) {
 	l := NewRateLimiter(0, 1)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if ok, _ := l.Reserve("k"); !ok {
 			t.Errorf("permissive limiter denied iter %d", i)
 		}
@@ -73,7 +73,7 @@ func TestRateLimiter_ZeroOrNegativeRateFallsBackToPermissive(t *testing.T) {
 
 func TestRateLimiter_ZeroBurstFallsBackToPermissive(t *testing.T) {
 	l := NewRateLimiter(1.0, 0)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if ok, _ := l.Reserve("k"); !ok {
 			t.Errorf("permissive limiter denied iter %d", i)
 		}

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -785,10 +786,7 @@ func sha256ContentHash(rendered string) string {
 // up to (history-1) most-recent entries from prior status.History,
 // dedup'd. Always at least 1 (the new rev). history<=0 falls back to 1.
 func buildKeepShortRevs(newRev string, prior []jaasv1.RevisionEntry, history int32) []string {
-	limit := int(history)
-	if limit < 1 {
-		limit = 1
-	}
+	limit := max(int(history), 1)
 	seen := map[string]struct{}{}
 	out := make([]string, 0, limit)
 
@@ -952,7 +950,7 @@ func (r *SnippetReconciler) cycleVerdict(ctx context.Context, snip *jaasv1.Jsonn
 		r.logger().DebugContext(ctx, "Snippet has empty UID; cycleCache cannot engage",
 			slog.String("namespace", snip.Namespace), slog.String("name", snip.Name))
 	}
-	for attempt := 0; attempt < maxCycleVerdictRetries; attempt++ {
+	for range maxCycleVerdictRetries {
 		v, epoch, ok := r.CycleCache.Lookup(snip.UID, snip.Generation)
 		if ok {
 			return v.hasCycle, v.path, nil
@@ -1447,12 +1445,8 @@ func mergeExtVars(opLevel, snipLevel map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(opLevel)+len(snipLevel))
-	for k, v := range opLevel {
-		out[k] = v
-	}
-	for k, v := range snipLevel {
-		out[k] = v
-	}
+	maps.Copy(out, opLevel)
+	maps.Copy(out, snipLevel)
 	return out
 }
 
@@ -1476,8 +1470,7 @@ func (r *SnippetReconciler) failReady(ctx context.Context, snip *jaasv1.JsonnetS
 	// prev as already-equal and suppresses the event.
 	var prev *metav1.Condition
 	if cur := apimeta.FindStatusCondition(snip.Status.Conditions, jaasv1.ConditionReady); cur != nil {
-		snapshot := *cur
-		prev = &snapshot
+		prev = new(*cur)
 	}
 	decorated := r.decorateMessage(reason, message)
 	helper, err := fluxpatch.NewHelper(snip, r.Client)
@@ -1581,7 +1574,6 @@ func (r *SnippetReconciler) markSynced(ctx context.Context, snip *jaasv1.Jsonnet
 	msg := fmt.Sprintf("Rendered %d bytes from %d files", len(rendered), sourceFileCount)
 	history := snip.Spec.History
 	now := r.now()
-	syncTime := metav1.NewTime(now)
 	key := types.NamespacedName{Name: snip.Name, Namespace: snip.Namespace}
 
 	// Staleness gate: a re-read confirms the spec we rendered is still
@@ -1633,7 +1625,7 @@ func (r *SnippetReconciler) markSynced(ctx context.Context, snip *jaasv1.Jsonnet
 		latest.Status.ArtifactURL = artifactURL
 	}
 	latest.Status.ObservedGeneration = latest.Generation
-	latest.Status.LastSyncTime = &syncTime
+	latest.Status.LastSyncTime = new(metav1.NewTime(now))
 	// Record that this reconcile handled the current
 	// reconcile.fluxcd.io/requestedAt token so `flux reconcile` can detect
 	// completion. The ReconcileRequestedPredicate fired on this token, so the
@@ -1709,10 +1701,7 @@ func (r *SnippetReconciler) now() time.Time {
 // in that case the existing head stays at its original timestamp
 // rather than rewriting it on every reconcile.
 func updateRevisionHistory(prior []jaasv1.RevisionEntry, revision string, historyMax int32, now time.Time) []jaasv1.RevisionEntry {
-	limit := int(historyMax)
-	if limit < 1 {
-		limit = 1
-	}
+	limit := max(int(historyMax), 1)
 	if len(prior) > 0 && prior[0].Revision == revision {
 		// Same head — leave the original timestamp in place, just
 		// truncate in case the limit shrank.

--- a/internal/operator/reconciler_test.go
+++ b/internal/operator/reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -137,13 +138,7 @@ func TestReconcile_AddsFinalizerOnFirstReconcile(t *testing.T) {
 	runReconcile(t, r, types.NamespacedName{Name: snip.Name, Namespace: snip.Namespace})
 
 	got := refetch(t, c, types.NamespacedName{Name: snip.Name, Namespace: snip.Namespace})
-	found := false
-	for _, f := range got.Finalizers {
-		if f == FinalizerName {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(got.Finalizers, FinalizerName)
 	if !found {
 		t.Errorf("Finalizers = %v, want %q present", got.Finalizers, FinalizerName)
 	}
@@ -151,8 +146,7 @@ func TestReconcile_AddsFinalizerOnFirstReconcile(t *testing.T) {
 
 func TestReconcile_DeletionTimestampWithFinalizerRemovesIt(t *testing.T) {
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -173,8 +167,7 @@ func TestReconcile_Delete_WithoutEffectiveSA_SkipsTokenCacheForget(t *testing.T)
 	// the "effective SA empty" branch.
 	snip := sampleSnippet()
 	snip.Spec.ServiceAccountName = ""
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -188,8 +181,7 @@ func TestReconcile_DeletionTimestampWithoutOurFinalizerIsNoOp(t *testing.T) {
 	// Another controller's finalizer keeps the object alive; ours is absent.
 	// We must not error and must leave the foreign finalizer untouched.
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{"some-other-controller/finalizer"}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -781,8 +773,7 @@ func TestReconcile_StatusUpdateErrorPropagates(t *testing.T) {
 
 func TestReconcile_DeleteUpdateErrorPropagates(t *testing.T) {
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	want := errors.New("conflict on finalizer drop")
 	c := fake.NewClientBuilder().
@@ -1122,8 +1113,7 @@ func TestReconcile_DeletionWithPublisher_WithdrawSucceeds(t *testing.T) {
 func TestReconcile_DeletionWithdrawErrorRequeues(t *testing.T) {
 	snip := sampleSnippet()
 	snip.Finalizers = []string{FinalizerName}
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 
 	want := errors.New("delete denied")
 	c := fake.NewClientBuilder().
@@ -1167,8 +1157,7 @@ func TestReconcileDelete_ErrorPathStillForgetsCycleVerdict(t *testing.T) {
 	snip := sampleSnippet()
 	snip.UID = types.UID("uid-delete-err")
 	snip.Finalizers = []string{FinalizerName}
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 
 	c := fake.NewClientBuilder().
 		WithScheme(publisherScheme(t)).
@@ -2213,8 +2202,7 @@ func TestReconcile_CycleDetectionTransientErrorWritesStatusAndRequeues(t *testin
 
 func TestReconcile_TenantClientErrorOnDeletePropagates(t *testing.T) {
 	snip := sampleSnippet()
-	now := metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC))
-	snip.DeletionTimestamp = &now
+	snip.DeletionTimestamp = new(metav1.NewTime(time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)))
 	snip.Finalizers = []string{FinalizerName}
 	c := clientWithStatus(t, snip)
 	r := newReconciler(t, c)
@@ -2762,7 +2750,7 @@ func TestReconcile_Events_DedupOnRepeatedSameReason(t *testing.T) {
 
 	// Finalizer attach (no events expected — failReady runs in spec
 	// branch only). Three more reconciles all hit ServiceAccountMissing.
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key}); err != nil {
 			t.Fatalf("reconcile %d: %v", i, err)
 		}
@@ -2823,8 +2811,7 @@ func TestIsLastSnippetUsingSA(t *testing.T) {
 			Spec:       jaasv1.JsonnetSnippetSpec{ServiceAccountName: sa},
 		}
 		if deleting {
-			now := metav1.Now()
-			s.DeletionTimestamp = &now
+			s.DeletionTimestamp = new(metav1.Now())
 			s.Finalizers = []string{"keep"} // fake client rejects a deleting object without a finalizer
 		}
 		return s

--- a/internal/operator/token.go
+++ b/internal/operator/token.go
@@ -48,10 +48,9 @@ func (m clientsetTokenMinter) Mint(ctx context.Context, namespace, serviceAccoun
 	if m.kc == nil {
 		return "", time.Time{}, errors.New("tokenMinter: nil Kubernetes clientset")
 	}
-	secs := int64(ttl.Seconds())
 	out, err := m.kc.CoreV1().ServiceAccounts(namespace).CreateToken(ctx, serviceAccount,
 		&authnv1.TokenRequest{
-			Spec: authnv1.TokenRequestSpec{ExpirationSeconds: &secs},
+			Spec: authnv1.TokenRequestSpec{ExpirationSeconds: new(int64(ttl.Seconds()))},
 		}, metav1.CreateOptions{})
 	if err != nil {
 		return "", time.Time{}, err
@@ -122,7 +121,7 @@ func (c *tokenCache) Token(ctx context.Context, namespace, serviceAccount string
 		return tok, nil
 	}
 
-	res, err, _ := c.flight.Do(key, func() (interface{}, error) {
+	res, err, _ := c.flight.Do(key, func() (any, error) {
 		// A double-check inside the singleflight closes the window where
 		// a previous Do completed and populated the cache while this
 		// caller was waiting for the lock.

--- a/internal/operator/token_test.go
+++ b/internal/operator/token_test.go
@@ -212,7 +212,7 @@ func TestTokenCache_ConcurrentTokenCallsForSameSA_SingleflightDedupesToOneMint(t
 	const n = 50
 	start := make(chan struct{})
 	done := make(chan string, n)
-	for i := 0; i < n; i++ {
+	for range n {
 		go func() {
 			<-start
 			tok, err := c.Token(context.Background(), "ns", "sa")
@@ -229,7 +229,7 @@ func TestTokenCache_ConcurrentTokenCallsForSameSA_SingleflightDedupesToOneMint(t
 	time.Sleep(20 * time.Millisecond)
 	close(gate)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		got := <-done
 		if got != "t" {
 			t.Errorf("caller %d got %q, want t", i, got)
@@ -251,7 +251,7 @@ func TestTokenCache_ConcurrentDistinctSAsMintConcurrently(t *testing.T) {
 	c := newTokenCache(calls)
 	const n = 10
 	done := make(chan struct{}, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		sa := "sa-" + string(rune('a'+i))
 		go func() {
 			_, _ = c.Token(context.Background(), "ns", sa)
@@ -260,7 +260,7 @@ func TestTokenCache_ConcurrentDistinctSAsMintConcurrently(t *testing.T) {
 	}
 	time.Sleep(20 * time.Millisecond)
 	close(gate)
-	for i := 0; i < n; i++ {
+	for range n {
 		<-done
 	}
 	if got := calls.count(); got != n {

--- a/internal/operator/tracing_test.go
+++ b/internal/operator/tracing_test.go
@@ -7,6 +7,7 @@ package operator
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,13 +98,7 @@ func TestEnvtest_Tracing_HappyReconcileEmitsFullTree(t *testing.T) {
 	}
 	got := spanNames(sr)
 	for _, want := range wantAll {
-		found := false
-		for _, name := range got {
-			if name == want {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(got, want)
 		if !found {
 			t.Errorf("span %q never emitted; got=%v", want, got)
 		}

--- a/internal/operator/watch_test.go
+++ b/internal/operator/watch_test.go
@@ -8,6 +8,7 @@ package operator
 import (
 	"context"
 	"errors"
+	"slices"
 	"sort"
 	"testing"
 
@@ -468,10 +469,8 @@ func TestFluxSourceKinds_IncludesExternalArtifact(t *testing.T) {
 	// when an upstream snippet republishes. The cycle detector
 	// (detectSourceRefCycle) prevents the publish → watch → reconcile →
 	// publish loop a cyclic sourceRef chain would otherwise create.
-	for _, k := range FluxSourceKinds {
-		if k == "ExternalArtifact" {
-			return
-		}
+	if slices.Contains(FluxSourceKinds, "ExternalArtifact") {
+		return
 	}
 	t.Errorf("FluxSourceKinds should include ExternalArtifact")
 }

--- a/internal/operator/webhook_test.go
+++ b/internal/operator/webhook_test.go
@@ -110,10 +110,9 @@ func TestSnippetValidator_ValidateUpdateChecksNewObj(t *testing.T) {
 // finalizer-removal update is blocked and the snippet wedges in Terminating.
 func TestSnippetValidator_ValidateUpdateSkipsObjectsUnderDeletion(t *testing.T) {
 	v := &SnippetValidator{OperatorExtVars: map[string]string{"cluster": "x"}}
-	now := metav1.Now()
 	snip := &jaasv1.JsonnetSnippet{
 		ObjectMeta: metav1.ObjectMeta{
-			DeletionTimestamp: &now,
+			DeletionTimestamp: new(metav1.Now()),
 			Finalizers:        []string{FinalizerName},
 		},
 		Spec: jaasv1.JsonnetSnippetSpec{

--- a/internal/sources/coverage_extra_test.go
+++ b/internal/sources/coverage_extra_test.go
@@ -151,7 +151,7 @@ func TestReadArtifactDigest_NonStringReturnsErrDigestInvalid(t *testing.T) {
 // --- readyState -----------------------------------------------------------
 
 func TestReadyState_NoConditionsSlice(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj := &unstructured.Unstructured{Object: map[string]any{}}
 	ok, why := readyState(obj)
 	if ok || why == "" {
 		t.Fatalf("absent conditions = (%v, %q), want (false, reason)", ok, why)
@@ -166,7 +166,7 @@ func TestReadyState_EmptyConditionsSlice(t *testing.T) {
 }
 
 func TestReadyState_ReadyTrue(t *testing.T) {
-	ok, why := readyState(unstructuredWithConditions([]map[string]interface{}{
+	ok, why := readyState(unstructuredWithConditions([]map[string]any{
 		{"type": "Ready", "status": "True"},
 	}))
 	if !ok || why != "" {
@@ -175,7 +175,7 @@ func TestReadyState_ReadyTrue(t *testing.T) {
 }
 
 func TestReadyState_ReadyFalseWithReason(t *testing.T) {
-	ok, why := readyState(unstructuredWithConditions([]map[string]interface{}{
+	ok, why := readyState(unstructuredWithConditions([]map[string]any{
 		{"type": "Ready", "status": "False", "reason": "Fetching"},
 	}))
 	if ok || !strings.Contains(why, "Fetching") {
@@ -184,7 +184,7 @@ func TestReadyState_ReadyFalseWithReason(t *testing.T) {
 }
 
 func TestReadyState_ReadyFalseWithoutReason(t *testing.T) {
-	ok, why := readyState(unstructuredWithConditions([]map[string]interface{}{
+	ok, why := readyState(unstructuredWithConditions([]map[string]any{
 		{"type": "Ready", "status": "False"},
 	}))
 	if ok || !strings.Contains(why, "Ready=False") {
@@ -193,10 +193,10 @@ func TestReadyState_ReadyFalseWithoutReason(t *testing.T) {
 }
 
 func TestReadyState_NonMapEntrySkipped(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	_ = unstructured.SetNestedSlice(obj.Object, []interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]any{}}
+	_ = unstructured.SetNestedSlice(obj.Object, []any{
 		"not-a-map",
-		map[string]interface{}{"type": "Ready", "status": "True"},
+		map[string]any{"type": "Ready", "status": "True"},
 	}, "status", "conditions")
 	ok, _ := readyState(obj)
 	if !ok {
@@ -205,7 +205,7 @@ func TestReadyState_NonMapEntrySkipped(t *testing.T) {
 }
 
 func TestReadyState_NoReadyEntryAmongOthers(t *testing.T) {
-	ok, why := readyState(unstructuredWithConditions([]map[string]interface{}{
+	ok, why := readyState(unstructuredWithConditions([]map[string]any{
 		{"type": "Stalled", "status": "True"},
 	}))
 	if ok || !strings.Contains(why, "no Ready") {

--- a/internal/sources/fuzz_test.go
+++ b/internal/sources/fuzz_test.go
@@ -8,6 +8,7 @@ package sources
 import (
 	"encoding/hex"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -82,13 +83,7 @@ func FuzzParseDigest(f *testing.F) {
 
 		// Acceptance invariants — these are what
 		// verifyExpectedDigest's switch relies on.
-		supported := false
-		for _, s := range supportedDigestAlgorithms {
-			if s == algo+":" {
-				supported = true
-				break
-			}
-		}
+		supported := slices.Contains(supportedDigestAlgorithms, algo+":")
 		if !supported {
 			t.Errorf("parseDigest accepted unsupported algo %q for %q", algo, declared)
 		}
@@ -199,7 +194,7 @@ func FuzzNormaliseEntry(f *testing.F) {
 		if strings.HasPrefix(out, "/") {
 			t.Errorf("accepted absolute path %q for (%q, %q)", out, rawName, prefix)
 		}
-		for _, part := range strings.Split(out, "/") {
+		for part := range strings.SplitSeq(out, "/") {
 			if part == ".." {
 				t.Errorf("accepted .. segment in %q for (%q, %q)", out, rawName, prefix)
 			}

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -576,7 +576,7 @@ func readyState(obj *unstructured.Unstructured) (bool, string) {
 		return false, "status.conditions empty"
 	}
 	for _, c := range conds {
-		m, ok := c.(map[string]interface{})
+		m, ok := c.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -903,7 +903,7 @@ func normaliseEntry(rawName, pathPrefix string) (string, bool) {
 		return "", false
 	}
 	cleaned := path.Clean(rawName)
-	for _, part := range strings.Split(cleaned, "/") {
+	for part := range strings.SplitSeq(cleaned, "/") {
 		if part == ".." {
 			return "", false
 		}

--- a/internal/sources/sources_property_test.go
+++ b/internal/sources/sources_property_test.go
@@ -83,7 +83,7 @@ func TestNormaliseEntry_AcceptedOutputIsSafe(t *testing.T) {
 		if strings.HasPrefix(out, "/") {
 			t.Fatalf("accepted output %q starts with '/' (raw=%q prefix=%q)", out, raw, prefix)
 		}
-		for _, seg := range strings.Split(out, "/") {
+		for seg := range strings.SplitSeq(out, "/") {
 			if seg == ".." {
 				t.Fatalf("accepted output %q contains a '..' segment (raw=%q prefix=%q)", out, raw, prefix)
 			}

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -517,7 +517,7 @@ func TestVerifyDigest_EmptyExpectedAccepted(t *testing.T) {
 }
 
 func TestIsReady_TrueCondition(t *testing.T) {
-	obj := unstructuredWithConditions([]map[string]interface{}{
+	obj := unstructuredWithConditions([]map[string]any{
 		{"type": "Ready", "status": "True"},
 	})
 	if ok, _ := readyState(obj); !ok {
@@ -526,7 +526,7 @@ func TestIsReady_TrueCondition(t *testing.T) {
 }
 
 func TestIsReady_FalseCondition(t *testing.T) {
-	obj := unstructuredWithConditions([]map[string]interface{}{
+	obj := unstructuredWithConditions([]map[string]any{
 		{"type": "Ready", "status": "False"},
 	})
 	if ok, _ := readyState(obj); ok {
@@ -535,7 +535,7 @@ func TestIsReady_FalseCondition(t *testing.T) {
 }
 
 func TestIsReady_OtherConditionsOnly(t *testing.T) {
-	obj := unstructuredWithConditions([]map[string]interface{}{
+	obj := unstructuredWithConditions([]map[string]any{
 		{"type": "Reconciling", "status": "True"},
 	})
 	if ok, _ := readyState(obj); ok {
@@ -544,7 +544,7 @@ func TestIsReady_OtherConditionsOnly(t *testing.T) {
 }
 
 func TestIsReady_MissingConditionsSlice(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj := &unstructured.Unstructured{Object: map[string]any{}}
 	if ok, _ := readyState(obj); ok {
 		t.Errorf("missing conditions misread as ready")
 	}
@@ -559,15 +559,15 @@ func TestReadyState_DiagnosticByShape(t *testing.T) {
 	}{
 		{
 			name:      "no conditions at all",
-			obj:       &unstructured.Unstructured{Object: map[string]interface{}{}},
+			obj:       &unstructured.Unstructured{Object: map[string]any{}},
 			wantReady: false,
 			wantWhy:   "status.conditions not yet populated",
 		},
 		{
 			name: "empty conditions slice",
 			obj: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"status": map[string]interface{}{"conditions": []interface{}{}},
+				Object: map[string]any{
+					"status": map[string]any{"conditions": []any{}},
 				},
 			},
 			wantReady: false,
@@ -575,7 +575,7 @@ func TestReadyState_DiagnosticByShape(t *testing.T) {
 		},
 		{
 			name: "Ready=False with reason",
-			obj: unstructuredWithConditions([]map[string]interface{}{
+			obj: unstructuredWithConditions([]map[string]any{
 				{"type": "Ready", "status": "False", "reason": "BuildFailed"},
 			}),
 			wantReady: false,
@@ -583,7 +583,7 @@ func TestReadyState_DiagnosticByShape(t *testing.T) {
 		},
 		{
 			name: "Ready=False without reason",
-			obj: unstructuredWithConditions([]map[string]interface{}{
+			obj: unstructuredWithConditions([]map[string]any{
 				{"type": "Ready", "status": "False"},
 			}),
 			wantReady: false,
@@ -591,7 +591,7 @@ func TestReadyState_DiagnosticByShape(t *testing.T) {
 		},
 		{
 			name: "no Ready condition among others",
-			obj: unstructuredWithConditions([]map[string]interface{}{
+			obj: unstructuredWithConditions([]map[string]any{
 				{"type": "Reconciling", "status": "True"},
 			}),
 			wantReady: false,
@@ -599,7 +599,7 @@ func TestReadyState_DiagnosticByShape(t *testing.T) {
 		},
 		{
 			name: "Ready=True",
-			obj: unstructuredWithConditions([]map[string]interface{}{
+			obj: unstructuredWithConditions([]map[string]any{
 				{"type": "Ready", "status": "True"},
 			}),
 			wantReady: true,
@@ -621,11 +621,11 @@ func TestReadyState_DiagnosticByShape(t *testing.T) {
 
 func TestIsReady_NonMapEntryInConditionsIsIgnored(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"conditions": []interface{}{
+		Object: map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
 					"not a map",
-					map[string]interface{}{"type": "Ready", "status": "True"},
+					map[string]any{"type": "Ready", "status": "True"},
 				},
 			},
 		},
@@ -637,9 +637,9 @@ func TestIsReady_NonMapEntryInConditionsIsIgnored(t *testing.T) {
 
 func TestReadArtifact_HappyPath(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"artifact": map[string]interface{}{
+		Object: map[string]any{
+			"status": map[string]any{
+				"artifact": map[string]any{
 					"url":      "http://x/y.tar.gz",
 					"revision": "rev1",
 					"digest":   "sha256:abc",
@@ -663,7 +663,7 @@ func TestReadArtifact_HappyPath(t *testing.T) {
 }
 
 func TestReadArtifact_MissingArtifact(t *testing.T) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj := &unstructured.Unstructured{Object: map[string]any{}}
 	if _, err := readArtifact(obj); !errors.Is(err, ErrArtifactMissing) {
 		t.Errorf("got %v, want ErrArtifactMissing", err)
 	}
@@ -671,9 +671,9 @@ func TestReadArtifact_MissingArtifact(t *testing.T) {
 
 func TestReadArtifact_MissingURL(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"artifact": map[string]interface{}{
+		Object: map[string]any{
+			"status": map[string]any{
+				"artifact": map[string]any{
 					"revision": "rev1",
 				},
 			},
@@ -687,8 +687,8 @@ func TestReadArtifact_MissingURL(t *testing.T) {
 func TestReadArtifact_BadShape(t *testing.T) {
 	// status.artifact is a string, not a map — NestedMap returns an error.
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{
+		Object: map[string]any{
+			"status": map[string]any{
 				"artifact": "not a map",
 			},
 		},
@@ -810,8 +810,8 @@ func TestFetch_SourceNotReady_ReturnsErrSourceNotReady(t *testing.T) {
 	defer srv.Close()
 
 	src := newFluxSourceUnstructured(t, "GitRepository", "configs", "team-a", srv.URL, sha256Hex(tarball))
-	_ = unstructured.SetNestedSlice(src.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "False"},
+	_ = unstructured.SetNestedSlice(src.Object, []any{
+		map[string]any{"type": "Ready", "status": "False"},
 	}, "status", "conditions")
 
 	c := fake.NewClientBuilder().WithScheme(schemeWithGVK(t, "GitRepository")).WithObjects(src).Build()
@@ -825,16 +825,16 @@ func TestFetch_SourceNotReady_ReturnsErrSourceNotReady(t *testing.T) {
 
 func TestFetch_ArtifactMissing_ReturnsErrArtifactMissing(t *testing.T) {
 	src := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": defaultSourceAPIVersion,
 			"kind":       "GitRepository",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "configs",
 				"namespace": "team-a",
 			},
-			"status": map[string]interface{}{
-				"conditions": []interface{}{
-					map[string]interface{}{"type": "Ready", "status": "True"},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True"},
 				},
 			},
 		},
@@ -1124,12 +1124,12 @@ func hexSHA256(body []byte) string {
 // the imports list inside individual tests stays focused.
 func newSHAHasher() hash.Hash { return sha256.New() }
 
-func unstructuredWithConditions(conds []map[string]interface{}) *unstructured.Unstructured {
-	items := make([]interface{}, 0, len(conds))
+func unstructuredWithConditions(conds []map[string]any) *unstructured.Unstructured {
+	items := make([]any, 0, len(conds))
 	for _, c := range conds {
 		items = append(items, c)
 	}
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj := &unstructured.Unstructured{Object: map[string]any{}}
 	_ = unstructured.SetNestedSlice(obj.Object, items, "status", "conditions")
 	return obj
 }
@@ -1144,7 +1144,7 @@ func newFluxSourceUnstructured(t *testing.T, kind, name, namespace, url, digest 
 	})
 	src.SetName(name)
 	src.SetNamespace(namespace)
-	artifact := map[string]interface{}{
+	artifact := map[string]any{
 		"url":      url,
 		"revision": "rev1",
 	}
@@ -1152,8 +1152,8 @@ func newFluxSourceUnstructured(t *testing.T, kind, name, namespace, url, digest 
 		artifact["digest"] = digest
 	}
 	_ = unstructured.SetNestedMap(src.Object, artifact, "status", "artifact")
-	_ = unstructured.SetNestedSlice(src.Object, []interface{}{
-		map[string]interface{}{"type": "Ready", "status": "True"},
+	_ = unstructured.SetNestedSlice(src.Object, []any{
+		map[string]any{"type": "Ready", "status": "True"},
 	}, "status", "conditions")
 	return src
 }
@@ -1278,7 +1278,7 @@ func TestFetcher_AcquireBoundsInFlightDownloads(t *testing.T) {
 		Build()
 
 	done := make(chan error, total)
-	for i := 0; i < total; i++ {
+	for range total {
 		go func() {
 			_, err := f.Fetch(context.Background(), c,
 				&jaasv1.SourceRef{Kind: "GitRepository", Name: "configs", Namespace: "team-a"}, "team-a")
@@ -1289,7 +1289,7 @@ func TestFetcher_AcquireBoundsInFlightDownloads(t *testing.T) {
 	// Give the goroutines a moment to fan in. The peak in-flight
 	// count must be exactly `cap` — the extra goroutines are stuck
 	// in acquire().
-	for tries := 0; tries < 100; tries++ {
+	for range 100 {
 		mu.Lock()
 		got := inFlight
 		mu.Unlock()
@@ -1306,10 +1306,10 @@ func TestFetcher_AcquireBoundsInFlightDownloads(t *testing.T) {
 
 	// Drain the server one request at a time and watch the peak
 	// stay at cap.
-	for i := 0; i < total; i++ {
+	for range total {
 		gate <- struct{}{}
 	}
-	for i := 0; i < total; i++ {
+	for i := range total {
 		if err := <-done; err != nil {
 			t.Errorf("Fetch %d: %v", i, err)
 		}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -517,7 +517,7 @@ func (b *S3Backend) HTTPHandler() http.Handler {
 		// 404s), but a normalizing S3-compatible gateway could otherwise resolve
 		// it and read outside the configured prefix — and every other
 		// key-constructing path in this package runs the same guard.
-		for _, seg := range strings.Split(key, "/") {
+		for seg := range strings.SplitSeq(key, "/") {
 			if seg == "" || seg == "." || seg == ".." {
 				http.NotFound(w, r)
 				return

--- a/internal/storage/s3_test.go
+++ b/internal/storage/s3_test.go
@@ -48,8 +48,7 @@ func TestS3Backend_SweepIsNoOp(t *testing.T) {
 // after stall/interval no-progress ticks it must fire onStall. Deterministic
 // — no real upload or sockets involved.
 func TestWatchUploadStall_TripsAfterNoProgress(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	tick := make(chan time.Time)
 	tripped := make(chan struct{})
 	var progress atomic.Int64 // never advances
@@ -59,7 +58,7 @@ func TestWatchUploadStall_TripsAfterNoProgress(t *testing.T) {
 		watchUploadStall(ctx, progress.Load, func() { close(tripped) }, 4*time.Second, time.Second, tick)
 	}()
 	// stall=4s, interval=1s → trips on the 4th no-progress tick.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		tick <- time.Time{}
 	}
 	select {
@@ -83,7 +82,7 @@ func TestWatchUploadStall_DoesNotTripWhileProgressing(t *testing.T) {
 		defer close(done)
 		watchUploadStall(ctx, progress.Load, func() { tripped.Store(true) }, 4*time.Second, time.Second, tick)
 	}()
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		progress.Add(1) // happens-before the tick send → watcher observes it
 		tick <- time.Time{}
 	}
@@ -862,10 +861,10 @@ func decodeAWSChunked(in []byte) []byte {
 		}
 		header := string(in[:nl])
 		in = in[nl+2:]
-		semi := strings.IndexByte(header, ';')
+		before, _, ok := strings.Cut(header, ";")
 		hexLen := header
-		if semi >= 0 {
-			hexLen = header[:semi]
+		if ok {
+			hexLen = before
 		}
 		var n int
 		for _, b := range []byte(hexLen) {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -593,10 +593,8 @@ func validTarEntryPath(p string) error {
 	if strings.ContainsRune(p, 0) || strings.ContainsRune(p, '\\') {
 		return fmt.Errorf("storage: tar entry %q contains a NUL or backslash", p)
 	}
-	for _, part := range strings.Split(p, "/") {
-		if part == ".." {
-			return fmt.Errorf("storage: tar entry %q contains a traversal", p)
-		}
+	if slices.Contains(strings.Split(p, "/"), "..") {
+		return fmt.Errorf("storage: tar entry %q contains a traversal", p)
 	}
 	return nil
 }

--- a/internal/storage/store_property_test.go
+++ b/internal/storage/store_property_test.go
@@ -36,7 +36,7 @@ func genFileEntries() *rapid.Generator[[]FileEntry] {
 	// the rejection path (which has its own unit tests).
 	pathGen := rapid.StringMatching(`[a-z0-9._\-]{1,12}(/[a-z0-9._\-]{1,12}){0,3}`).
 		Filter(func(s string) bool {
-			for _, seg := range strings.Split(s, "/") {
+			for seg := range strings.SplitSeq(s, "/") {
 				if seg == "." || seg == ".." {
 					return false
 				}

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -315,7 +315,7 @@ func TestPrune_EmptyComponentRejected(t *testing.T) {
 func TestStore_ConcurrentPutsAreSafe(t *testing.T) {
 	s := newTestStore(t)
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/internal/webhook/selfsigned/cert_test.go
+++ b/internal/webhook/selfsigned/cert_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -68,13 +69,7 @@ func TestGenerate_DefaultsServiceName(t *testing.T) {
 	}
 	cert := parseCert(t, b.CertPEM)
 	wantDNS := "jaas-webhook.jaas-system.svc"
-	found := false
-	for _, n := range cert.DNSNames {
-		if n == wantDNS {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(cert.DNSNames, wantDNS)
 	if !found {
 		t.Errorf("DNS SANs %v missing default %q", cert.DNSNames, wantDNS)
 	}
@@ -91,13 +86,7 @@ func TestGenerate_DNSNamesIncludeClusterLocal(t *testing.T) {
 		"jaas-webhook.jaas-system.svc.cluster.local",
 	}
 	for _, want := range wantBoth {
-		found := false
-		for _, got := range cert.DNSNames {
-			if got == want {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(cert.DNSNames, want)
 		if !found {
 			t.Errorf("DNS SAN %q missing from %v", want, cert.DNSNames)
 		}

--- a/internal/webhook/selfsigned/envtest_test.go
+++ b/internal/webhook/selfsigned/envtest_test.go
@@ -41,16 +41,14 @@ func TestEnvtest_SelfSignedFlow_PatchesVWCEndToEnd(t *testing.T) {
 	}
 	vwcs := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 
-	failurePolicy := admissionv1.Fail
-	sideEffects := admissionv1.SideEffectClassNone
 	vwc := &admissionv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-selfsigned"},
 		Webhooks: []admissionv1.ValidatingWebhook{
 			{
 				Name:                    "vtest.example.com",
 				AdmissionReviewVersions: []string{"v1"},
-				FailurePolicy:           &failurePolicy,
-				SideEffects:             &sideEffects,
+				FailurePolicy:           new(admissionv1.Fail),
+				SideEffects:             new(admissionv1.SideEffectClassNone),
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{
 						Name:      "jaas-webhook",
@@ -153,16 +151,14 @@ func TestEnvtest_SelfSignedFlow_RotateRePatchesVWC(t *testing.T) {
 	}
 	vwcs := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 
-	failurePolicy := admissionv1.Fail
-	sideEffects := admissionv1.SideEffectClassNone
 	vwc := &admissionv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-rotate"},
 		Webhooks: []admissionv1.ValidatingWebhook{
 			{
 				Name:                    "vrotate.example.com",
 				AdmissionReviewVersions: []string{"v1"},
-				FailurePolicy:           &failurePolicy,
-				SideEffects:             &sideEffects,
+				FailurePolicy:           new(admissionv1.Fail),
+				SideEffects:             new(admissionv1.SideEffectClassNone),
 				ClientConfig: admissionv1.WebhookClientConfig{
 					Service: &admissionv1.ServiceReference{Name: "x", Namespace: "default"},
 				},

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -223,9 +224,7 @@ func run(args, env []string, stdout, stderr io.Writer, sigs <-chan os.Signal) in
 	// CLI --ext-var overlays env-derived JAAS_EXT_VAR_* on key conflicts;
 	// the env mechanism predates the flag and is kept for the HTTP-only path.
 	extVars := handler.ParseExtVars(env)
-	for k, v := range cliExtVars {
-		extVars[k] = v
-	}
+	maps.Copy(extVars, cliExtVars)
 	slog.InfoContext(ctx, "External variables loaded",
 		slog.Int("count", len(extVars)),
 		slog.Int("from-cli", len(cliExtVars)))
@@ -633,10 +632,7 @@ func awaitGoroutines(ctx context.Context, timeout time.Duration, dones map[strin
 // throughput gain; the cap exists to bound worst-case goroutine
 // pile-up under a runaway snippet, not to clip steady-state throughput.
 func defaultMaxConcurrentEvals() int {
-	n := runtime.GOMAXPROCS(0) * 4
-	if n < 16 {
-		n = 16
-	}
+	n := max(runtime.GOMAXPROCS(0)*4, 16)
 	return n
 }
 
@@ -663,7 +659,7 @@ func parseWatchNamespaces(flagValue string, env []string) []string {
 		return nil
 	}
 	var out []string
-	for _, part := range strings.Split(raw, ",") {
+	for part := range strings.SplitSeq(raw, ",") {
 		if p := strings.TrimSpace(part); p != "" {
 			out = append(out, p)
 		}

--- a/mcp_cmd.go
+++ b/mcp_cmd.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"time"
 
@@ -62,9 +63,7 @@ func runMCP(args, env []string, _, stderr io.Writer, sigs <-chan os.Signal) int 
 	// CLI --ext-var overlays env-derived JAAS_EXT_VAR_* on key conflicts,
 	// matching the main binary.
 	extVars := handler.ParseExtVars(env)
-	for k, v := range cliExtVars {
-		extVars[k] = v
-	}
+	maps.Copy(extVars, cliExtVars)
 
 	// Bound concurrent evaluations with the same default the HTTP path uses so
 	// a runaway snippet from a client can't pile up unbounded goroutines.


### PR DESCRIPTION
Apply golang.org/x/tools modernize fixes across the tree: new(expr) for pointer-to-value, range-over-int loops, slices.Contains, strings.Cut / CutPrefix, and strings.SplitSeq ranging; drop now-unused pointer-helper wrappers. Install modernize in the dev image so the lint gate reproduces locally. (Generated zz_generated.deepcopy.go is left untouched; its maps.Copy hits are excluded from the gate.)