### PR TITLE
fix: five medium-severity defects across storage, publisher, webhook,…

### DIFF
--- a/internal/mcp/coverage_extra_test.go
+++ b/internal/mcp/coverage_extra_test.go
@@ -361,3 +361,26 @@ func TestMutateSnippet_PatchError(t *testing.T) {
 		t.Fatalf("error should mention the failed update, got %q", textContent(t, res))
 	}
 }
+
+// TestConfinedImporter_RightmostRootWins pins the JPATH precedence contract:
+// go-jsonnet's FileImporter iterates JPaths in reverse, so on a collision the
+// RIGHTMOST --library-path wins — the confined importer must agree, or the
+// same flags resolve differently on the confined MCP path than on the
+// HTTP/stdio paths. TestExamples_LibraryPrecedence pins the FileImporter side.
+func TestConfinedImporter_RightmostRootWins(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	for root, body := range map[string]string{rootA: `{ from: "A" }`, rootB: `{ from: "B" }`} {
+		if err := os.WriteFile(filepath.Join(root, "shared.libsonnet"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	imp := newConfinedImporter([]string{rootA, rootB})
+	contents, foundAt, err := imp.Import("", "shared.libsonnet")
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if got := contents.String(); got != `{ from: "B" }` {
+		t.Fatalf("resolved %q from %q — leftmost root won; the rightmost --library-path must take precedence", got, foundAt)
+	}
+}

--- a/internal/mcp/importer.go
+++ b/internal/mcp/importer.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 
 	"github.com/google/go-jsonnet"
 )
@@ -56,8 +57,11 @@ func (imp *confinedImporter) Import(importedFrom, importedPath string) (jsonnet.
 	if root, dir, ok := imp.locate(importedFrom); ok {
 		candidates = append(candidates, candidate{root, path.Join(dir, importedPath)})
 	}
-	// (2) Each root, searched in order — the JPATH semantics.
-	for _, root := range imp.roots {
+	// (2) Each root, searched RIGHTMOST FIRST — go-jsonnet's FileImporter
+	// iterates JPaths in reverse, so the rightmost --library-path wins on a
+	// collision. The confined importer must agree, or the same flags resolve
+	// differently between the HTTP/stdio paths and the confined MCP path.
+	for _, root := range slices.Backward(imp.roots) {
 		candidates = append(candidates, candidate{root, importedPath})
 	}
 

--- a/internal/operator/publisher.go
+++ b/internal/operator/publisher.go
@@ -25,6 +25,7 @@ import (
 	fluxpatch "github.com/fluxcd/pkg/runtime/patch"
 
 	jaasv1 "github.com/metio/jaas/api/v1"
+	"github.com/metio/jaas/internal/sources"
 	"github.com/metio/jaas/internal/storage"
 )
 
@@ -86,6 +87,11 @@ type Publisher struct {
 // ReasonArtifactTooLarge on the Ready condition.
 var ErrArtifactTooLarge = errors.New("publisher: artifact exceeds MaxArtifactBytes")
 
+// ErrUnsafeEntryName is returned from Publish in Output=source mode when a
+// source file's name would be silently dropped by every consumer's extractor —
+// a snippet-author problem the reconciler surfaces as InvalidSpec.
+var ErrUnsafeEntryName = errors.New("publisher: source entry name would be dropped by consumers")
+
 // NewPublisher returns a Publisher whose Clock falls back to time.Now.
 func NewPublisher(store storage.Backend, baseURL string) *Publisher {
 	return &Publisher{Store: store, BaseURL: baseURL, Clock: time.Now}
@@ -128,14 +134,27 @@ func (p *Publisher) Publish(ctx context.Context, c client.Client, snip *jaasv1.J
 	// is the whole sourceFiles tree — len(rendered) would not measure that.
 	// Summing the built entries' bytes is the right measure because those
 	// are exactly the bytes Store.Put writes into the tarball.
-	if p.MaxArtifactBytes > 0 {
-		var total int64
-		for _, e := range entries {
-			total += int64(len(e.Content))
+	//
+	// Two layers: MaxArtifactBytes is the operator's own knob (zero = no
+	// operator cap), but the CONSUMER caps are unconditional — every fetcher
+	// (jaas's chaining fetcher, stageset's artifact fetcher) hard-caps
+	// extraction at sources.DefaultMaxPerEntryBytes per entry and
+	// sources.DefaultMaxExtractedBytes aggregate, so publishing past those
+	// bounds stamps Ready=True on an artifact no consumer can ever fetch.
+	var total int64
+	for _, e := range entries {
+		if int64(len(e.Content)) > sources.DefaultMaxPerEntryBytes {
+			return PublishResult{}, fmt.Errorf("%w: entry %q is %d bytes; consumers cap extraction at %d bytes per entry",
+				ErrArtifactTooLarge, e.Path, len(e.Content), sources.DefaultMaxPerEntryBytes)
 		}
-		if total > p.MaxArtifactBytes {
-			return PublishResult{}, fmt.Errorf("%w: %d > %d", ErrArtifactTooLarge, total, p.MaxArtifactBytes)
-		}
+		total += int64(len(e.Content))
+	}
+	if total > sources.DefaultMaxExtractedBytes {
+		return PublishResult{}, fmt.Errorf("%w: %d bytes total; consumers cap extraction at %d bytes",
+			ErrArtifactTooLarge, total, sources.DefaultMaxExtractedBytes)
+	}
+	if p.MaxArtifactBytes > 0 && total > p.MaxArtifactBytes {
+		return PublishResult{}, fmt.Errorf("%w: %d > %d", ErrArtifactTooLarge, total, p.MaxArtifactBytes)
 	}
 	res, err := p.Store.Put(ctx, snip.Namespace, snip.Name, revision, entries)
 	if err != nil {
@@ -225,6 +244,15 @@ func (p *Publisher) buildEntries(snip *jaasv1.JsonnetSnippet, rendered string, s
 	case jaasv1.OutputSource:
 		entries := make([]storage.FileEntry, 0, len(sourceFiles))
 		for path, body := range sourceFiles {
+			// Source mode ships the file NAMES to consumers, and every
+			// consumer's extractor silently drops names it considers unsafe —
+			// the file would just never arrive downstream. Refuse to publish
+			// such an entry instead. Inline spec.files keys are the
+			// unvalidated door (fetched trees already passed a fetcher's own
+			// normalisation on the way in).
+			if !sources.SafeEntryName(path) {
+				return nil, "", fmt.Errorf("%w: %q (allowed: [A-Za-z0-9._/-] segments, no dot-prefixed segments, no traversal)", ErrUnsafeEntryName, path)
+			}
 			entries = append(entries, storage.FileEntry{Path: path, Content: []byte(body)})
 		}
 		return entries, sourceArchiveRevision(sourceFiles), nil

--- a/internal/operator/publisher_caps_test.go
+++ b/internal/operator/publisher_caps_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: The jaas Authors
+// SPDX-License-Identifier: 0BSD
+
+package operator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	jaasv1 "github.com/metio/jaas/api/v1"
+	"github.com/metio/jaas/internal/sources"
+)
+
+// A single entry above the consumers' hard per-entry extraction cap must fail
+// the publish — with no operator MaxArtifactBytes set at all. Publishing it
+// would stamp Ready=True on an artifact every fetcher (jaas chaining,
+// stageset) silently refuses, permanently.
+func TestPublisher_RejectsEntryOverConsumerCap(t *testing.T) {
+	p := newTestPublisher(t, nil)
+	c := newPublisherClient(t)
+	snip := sampleSnippet() // Output defaults to rendered: one rendered.json entry
+
+	huge := strings.Repeat("x", int(sources.DefaultMaxPerEntryBytes)+1)
+	_, err := p.Publish(context.Background(), c, snip, huge, nil, nil)
+	if !errors.Is(err, ErrArtifactTooLarge) {
+		t.Fatalf("Publish = %v, want ErrArtifactTooLarge for an entry consumers cannot extract", err)
+	}
+	if !strings.Contains(err.Error(), "rendered.json") {
+		t.Errorf("error should name the offending entry, got: %v", err)
+	}
+}
+
+// Entries individually under the per-entry cap but summing past the aggregate
+// extraction cap must fail too — the consumer's ErrTarballTooLarge would
+// reject the whole fetch.
+func TestPublisher_RejectsTotalOverConsumerCap(t *testing.T) {
+	p := newTestPublisher(t, nil)
+	c := newPublisherClient(t)
+	snip := sampleSnippet()
+	snip.Spec.Output = jaasv1.OutputSource
+
+	chunk := strings.Repeat("y", 13<<20) // 13 MiB, under the 16 MiB per-entry cap
+	files := map[string]string{}
+	for _, name := range []string{"a.jsonnet", "b.jsonnet", "c.jsonnet", "d.jsonnet", "e.jsonnet"} {
+		files[name] = chunk // 65 MiB total, over the 64 MiB aggregate cap
+	}
+	_, err := p.Publish(context.Background(), c, snip, "", files, nil)
+	if !errors.Is(err, ErrArtifactTooLarge) {
+		t.Fatalf("Publish = %v, want ErrArtifactTooLarge for a total consumers cannot extract", err)
+	}
+}
+
+// The operator's own MaxArtifactBytes knob still tightens below the consumer
+// caps — the unconditional consumer bound is a ceiling, not a replacement.
+func TestPublisher_OperatorCapStillTightens(t *testing.T) {
+	p := newTestPublisher(t, nil)
+	p.MaxArtifactBytes = 16
+	c := newPublisherClient(t)
+	snip := sampleSnippet()
+
+	_, err := p.Publish(context.Background(), c, snip, strings.Repeat("z", 64), nil, nil)
+	if !errors.Is(err, ErrArtifactTooLarge) {
+		t.Fatalf("Publish = %v, want ErrArtifactTooLarge from the operator cap", err)
+	}
+}
+
+// A source entry whose name every consumer's extractor silently drops must
+// fail the publish as a spec problem — the file would never arrive downstream.
+func TestPublisher_RejectsUnsafeSourceEntryName(t *testing.T) {
+	p := newTestPublisher(t, nil)
+	c := newPublisherClient(t)
+	snip := sampleSnippet()
+	snip.Spec.Output = jaasv1.OutputSource
+
+	cases := map[string]string{
+		"space":       "deploy config.yaml",
+		"dot-segment": ".hidden/main.jsonnet",
+		"traversal":   "../escape.jsonnet",
+		"backslash":   `windows\path.jsonnet`,
+	}
+	for name, key := range cases {
+		t.Run(name, func(t *testing.T) {
+			files := map[string]string{"main.jsonnet": "{}", key: "{}"}
+			_, err := p.Publish(context.Background(), c, snip, "", files, nil)
+			if !errors.Is(err, ErrUnsafeEntryName) {
+				t.Fatalf("Publish with key %q = %v, want ErrUnsafeEntryName", key, err)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("%q", key)) {
+				t.Errorf("error should name the offending key, got: %v", err)
+			}
+		})
+	}
+}
+
+// Safe names keep publishing — the guard must not overshoot the charset every
+// consumer accepts.
+func TestPublisher_SafeSourceNamesPublish(t *testing.T) {
+	p := newTestPublisher(t, nil)
+	c := newPublisherClient(t)
+	snip := sampleSnippet()
+	snip.Spec.Output = jaasv1.OutputSource
+
+	files := map[string]string{
+		"main.jsonnet":              "{}",
+		"lib/helpers.libsonnet":     "{}",
+		"data/config_v2.snake.json": "{}",
+		"UPPER-case.and-dash.txt":   "ok",
+	}
+	if _, err := p.Publish(context.Background(), c, snip, "", files, nil); err != nil {
+		t.Fatalf("Publish with consumer-safe names should succeed: %v", err)
+	}
+}

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -800,6 +800,12 @@ func (r *SnippetReconciler) reconcileSpec(ctx context.Context, logger *slog.Logg
 		if errors.Is(err, ErrArtifactTooLarge) {
 			return r.failReady(ctx, snip, ReasonArtifactTooLarge, err.Error())
 		}
+		// A source entry name every consumer would silently drop is a
+		// spec problem too — publishing it would ship an artifact whose
+		// file never arrives downstream.
+		if errors.Is(err, ErrUnsafeEntryName) {
+			return r.failReady(ctx, snip, ReasonInvalidSpec, err.Error())
+		}
 		// RBAC denial / missing CRD during the ExternalArtifact
 		// upsert — non-recoverable by retry until the cluster
 		// operator grants the verb. Stop engaging backoff.

--- a/internal/operator/webhook.go
+++ b/internal/operator/webhook.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	jaasv1 "github.com/metio/jaas/api/v1"
+	"github.com/metio/jaas/internal/sources"
 )
 
 // SnippetValidator is the admission webhook for JsonnetSnippet. It rejects:
@@ -79,6 +80,17 @@ func (v *SnippetValidator) validate(ctx context.Context, snip *jaasv1.JsonnetSni
 	}
 	if dup := duplicateLibraryImportPath(snip); dup != "" {
 		return nil, fmt.Errorf("spec.libraries import path %q is used by more than one entry; each library must resolve to a distinct import path", dup)
+	}
+	// Output=source ships the file NAMES to consumers, whose extractors
+	// silently drop names outside the safe charset — the file would just
+	// never arrive downstream. Reject at admission so the author hears it
+	// on apply; the Publisher enforces the same rule as the fallback.
+	if snip.Spec.Output == jaasv1.OutputSource {
+		for name := range snip.Spec.Files {
+			if !sources.SafeEntryName(name) {
+				return nil, fmt.Errorf("spec.files key %q would be silently dropped by artifact consumers in output=source mode (allowed: [A-Za-z0-9._/-] segments, no dot-prefixed segments, no traversal)", name)
+			}
+		}
 	}
 	if v.Client != nil {
 		cycle, path, err := detectSourceRefCycle(ctx, v.Client, snip)

--- a/internal/operator/webhook_test.go
+++ b/internal/operator/webhook_test.go
@@ -443,3 +443,57 @@ func TestSnippetValidator_NoWarningsOnHealthyShape(t *testing.T) {
 		t.Errorf("expected no warnings on healthy shape, got %v", warnings)
 	}
 }
+
+// Output=source ships file NAMES to consumers, whose extractors silently drop
+// unsafe ones — admission rejects such keys so the author hears it on apply.
+func TestSnippetValidator_SourceModeUnsafeFileNameRejected(t *testing.T) {
+	v := &SnippetValidator{}
+	snip := &jaasv1.JsonnetSnippet{
+		Spec: jaasv1.JsonnetSnippetSpec{
+			Output: jaasv1.OutputSource,
+			SnippetSource: jaasv1.SnippetSource{Files: map[string]string{
+				"main.jsonnet":      "{}",
+				"deploy config.yml": "{}", // space: every consumer drops it
+			}},
+		},
+	}
+	if _, err := v.ValidateCreate(context.Background(), snip); err == nil {
+		t.Fatal("a source-mode file name consumers drop must be rejected at admission")
+	} else if !strings.Contains(err.Error(), "deploy config.yml") {
+		t.Errorf("error should name the offending key, got: %v", err)
+	}
+}
+
+// Rendered mode publishes only rendered.json — the same key stays legal there,
+// where it is purely a local eval file name.
+func TestSnippetValidator_RenderedModeFileNamesUnrestricted(t *testing.T) {
+	v := &SnippetValidator{}
+	snip := &jaasv1.JsonnetSnippet{
+		Spec: jaasv1.JsonnetSnippetSpec{
+			SnippetSource: jaasv1.SnippetSource{Files: map[string]string{
+				"main.jsonnet":      "{}",
+				"deploy config.yml": "{}",
+			}},
+		},
+	}
+	if _, err := v.ValidateCreate(context.Background(), snip); err != nil {
+		t.Fatalf("rendered mode must not restrict local file names: %v", err)
+	}
+}
+
+// Safe source-mode names pass admission.
+func TestSnippetValidator_SourceModeSafeFileNamesPass(t *testing.T) {
+	v := &SnippetValidator{}
+	snip := &jaasv1.JsonnetSnippet{
+		Spec: jaasv1.JsonnetSnippetSpec{
+			Output: jaasv1.OutputSource,
+			SnippetSource: jaasv1.SnippetSource{Files: map[string]string{
+				"main.jsonnet":          "{}",
+				"lib/helpers.libsonnet": "{}",
+			}},
+		},
+	}
+	if _, err := v.ValidateCreate(context.Background(), snip); err != nil {
+		t.Fatalf("consumer-safe source names must pass admission: %v", err)
+	}
+}

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -951,3 +951,25 @@ func isSafePathByte(b byte) bool {
 		return false
 	}
 }
+
+// Consumer-contract exports: the Publisher refuses to publish what these
+// bounds would make every consumer refuse to fetch — a Ready=True artifact
+// nobody can consume is worse than a failed publish.
+
+// DefaultMaxPerEntryBytes is the per-entry extraction cap every fetcher
+// applies (jaas's own chaining fetcher and stageset's artifact fetcher use
+// the same value).
+const DefaultMaxPerEntryBytes = defaultMaxPerEntryBytes
+
+// DefaultMaxExtractedBytes is the aggregate extracted-content cap.
+const DefaultMaxExtractedBytes = defaultMaxExtractedBytes
+
+// SafeEntryName reports whether consumers will keep a tar entry of this name.
+// The extractor silently DROPS entries that fail normalisation (unsafe bytes
+// outside [A-Za-z0-9._/-], dot-prefixed segments, traversal, backslash), so a
+// producer publishing such a name ships an artifact whose file quietly never
+// arrives; producers validate here instead.
+func SafeEntryName(name string) bool {
+	_, ok := normaliseEntry(name, "")
+	return ok
+}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -100,8 +100,10 @@ type S3Config struct {
 	// a bucket with anonymous read+write ACL (testing).
 	UseAnonymous bool
 
-	// ReadTimeout caps a single GetObject stream. Zero uses the
-	// surrounding http.Server's write timeout.
+	// ReadTimeout caps the time to first byte of a GetObject (dial,
+	// request, response headers). The body stream itself is bounded by the
+	// surrounding http.Server's write timeout, matching the local backend.
+	// Zero disables the first-byte bound.
 	ReadTimeout time.Duration
 }
 
@@ -531,11 +533,19 @@ func (b *S3Backend) HTTPHandler() http.Handler {
 		if b.prefix != "" {
 			key = b.prefix + "/" + key
 		}
-		ctx := r.Context()
+		// readTimeout bounds only the TIME TO FIRST BYTE (dial, request,
+		// response headers via Stat) — not the body stream. The minio object
+		// reader is bound to the ctx given at GetObject for its whole life, so
+		// a WithTimeout here would sever slow-but-progressing streams mid-body
+		// after 200 + Content-Length are on the wire; the local backend has no
+		// such internal cap. The body is bounded by the surrounding
+		// http.Server's write timeout, the same budget the local backend
+		// streams under, so the two backends behave alike.
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		var ttfb *time.Timer
 		if b.readTimeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, b.readTimeout)
-			defer cancel()
+			ttfb = time.AfterFunc(b.readTimeout, cancel)
 		}
 		obj, err := b.client.GetObject(ctx, b.bucket, key, minio.GetObjectOptions{})
 		if err != nil {
@@ -544,6 +554,9 @@ func (b *S3Backend) HTTPHandler() http.Handler {
 		}
 		defer obj.Close()
 		info, err := obj.Stat()
+		if ttfb != nil {
+			ttfb.Stop()
+		}
 		if err != nil {
 			s3WriteError(w, err)
 			return

--- a/internal/storage/s3_timeout_test.go
+++ b/internal/storage/s3_timeout_test.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: The jaas Authors
+// SPDX-License-Identifier: 0BSD
+
+package storage
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// dribbleS3 answers path-style GETs for one object, writing the body in
+// chunks with a delay between them — a slow-but-progressing stream. delayFirst
+// holds the whole response (headers included) to exercise the first-byte bound.
+type dribbleS3 struct {
+	bucket     string
+	key        string
+	body       []byte
+	chunks     int
+	chunkDelay time.Duration
+	delayFirst time.Duration
+}
+
+func (f *dribbleS3) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// minio-go probes the bucket location before the first object call;
+	// answer instantly so only the object GET carries the configured delays.
+	if r.URL.Query().Has("location") {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>`))
+		return
+	}
+	if f.delayFirst > 0 {
+		time.Sleep(f.delayFirst)
+	}
+	want := "/" + f.bucket + "/" + f.key
+	if r.URL.Path != want {
+		http.Error(w, "no such key", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(f.body)))
+	w.Header().Set("Content-Type", "application/octet-stream")
+	// minio-go's Stat requires a parseable object-info header set.
+	w.Header().Set("Last-Modified", "Mon, 1 Jan 2024 00:00:00 GMT")
+	w.Header().Set("ETag", `"00000000000000000000000000000000"`)
+	w.WriteHeader(http.StatusOK)
+	if r.Method == http.MethodHead {
+		return
+	}
+	fl, _ := w.(http.Flusher)
+	size := (len(f.body) + f.chunks - 1) / f.chunks
+	for off := 0; off < len(f.body); off += size {
+		end := min(off+size, len(f.body))
+		_, _ = w.Write(f.body[off:end])
+		if fl != nil {
+			fl.Flush()
+		}
+		time.Sleep(f.chunkDelay)
+	}
+}
+
+func newTimeoutBackend(t *testing.T, fake http.Handler, readTimeout time.Duration) *S3Backend {
+	t.Helper()
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse fake URL: %v", err)
+	}
+	b, err := NewS3(S3Config{
+		Endpoint:        u.Host,
+		Bucket:          "bkt",
+		UseSSL:          false,
+		AccessKeyID:     "test",
+		SecretAccessKey: "test",
+		ReadTimeout:     readTimeout,
+	})
+	if err != nil {
+		t.Fatalf("NewS3: %v", err)
+	}
+	return b
+}
+
+// A slow-but-progressing body stream must arrive COMPLETE: ReadTimeout bounds
+// only the time to first byte, never the body copy — a stream slower than the
+// old whole-request deadline was silently truncated after 200 + Content-Length
+// were already on the wire, corrupting every consumer's fetch. The body budget
+// is the surrounding http.Server's write timeout, exactly like the local
+// backend.
+func TestS3_HTTPHandler_SlowBodyIsNotTruncatedByReadTimeout(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), 64<<10)
+	fake := &dribbleS3{
+		bucket: "bkt", key: "ns/snip/rev1.tar.gz", body: body,
+		chunks: 8, chunkDelay: 60 * time.Millisecond, // ~480ms total, well past ReadTimeout
+	}
+	b := newTimeoutBackend(t, fake, 150*time.Millisecond)
+
+	rec := httptest.NewRecorder()
+	b.HTTPHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ns/snip/rev1.tar.gz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String()[:min(rec.Body.Len(), 200)])
+	}
+	if rec.Body.Len() != len(body) {
+		t.Fatalf("streamed %d of %d bytes: the read timeout truncated a progressing body", rec.Body.Len(), len(body))
+	}
+}
+
+// ReadTimeout still bounds a backend that never starts responding: the
+// first-byte guard is kept, only the body copy is released from it.
+func TestS3_HTTPHandler_SlowFirstByteIsBounded(t *testing.T) {
+	fake := &dribbleS3{
+		bucket: "bkt", key: "ns/snip/rev1.tar.gz", body: []byte("late"),
+		chunks: 1, delayFirst: 2 * time.Second,
+	}
+	b := newTimeoutBackend(t, fake, 100*time.Millisecond)
+
+	start := time.Now()
+	rec := httptest.NewRecorder()
+	b.HTTPHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ns/snip/rev1.tar.gz", nil))
+	if rec.Code == http.StatusOK && rec.Body.Len() > 0 {
+		t.Fatalf("a backend that exceeds the first-byte bound must not stream a body, got %d bytes", rec.Body.Len())
+	}
+	if elapsed := time.Since(start); elapsed > 1500*time.Millisecond {
+		t.Fatalf("first-byte bound did not fire; handler blocked %s", elapsed)
+	}
+}
+
+// Guards the error path shape: exceeding the first-byte bound surfaces as an
+// HTTP error status (via s3WriteError), not a hung or empty-200 response.
+func TestS3_HTTPHandler_FirstByteTimeoutIsAnErrorStatus(t *testing.T) {
+	fake := &dribbleS3{
+		bucket: "bkt", key: "ns/snip/rev1.tar.gz", body: []byte("late"),
+		chunks: 1, delayFirst: 2 * time.Second,
+	}
+	b := newTimeoutBackend(t, fake, 100*time.Millisecond)
+
+	rec := httptest.NewRecorder()
+	b.HTTPHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ns/snip/rev1.tar.gz", nil))
+	if rec.Code < 400 {
+		t.Fatalf("status = %d, want an error status for a timed-out first byte; body=%q", rec.Code, strings.TrimSpace(rec.Body.String()))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -435,22 +435,18 @@ func run(args, env []string, stdout, stderr io.Writer, sigs <-chan os.Signal) in
 				slog.ErrorContext(ctx, "Cannot build MCP Kubernetes client", slog.Any("error", err))
 				return 1
 			}
-			mcpServer = &http.Server{
-				Addr:        *f.MCPBindAddress,
-				ReadTimeout: *f.ReadTimeout,
-				Handler: mcp.NewHTTPHandler(mcp.Config{
-					Version:           version,
-					Logger:            slog.Default(),
-					LibraryPaths:      *f.LibraryPaths,
-					ExtVars:           extVars,
-					MaxStack:          *f.MaxStack,
-					EvaluationTimeout: *f.EvaluationTimeout,
-					KubeClient:        mcpKubeClient,
-					RunbookBaseURL:    operator.RunbookBaseURL,
-					AllowMutations:    *f.MCPAllowMutations,
-					Store:             opStore,
-				}),
-			}
+			mcpServer = newMCPHTTPServer(*f.MCPBindAddress, mcp.NewHTTPHandler(mcp.Config{
+				Version:           version,
+				Logger:            slog.Default(),
+				LibraryPaths:      *f.LibraryPaths,
+				ExtVars:           extVars,
+				MaxStack:          *f.MaxStack,
+				EvaluationTimeout: *f.EvaluationTimeout,
+				KubeClient:        mcpKubeClient,
+				RunbookBaseURL:    operator.RunbookBaseURL,
+				AllowMutations:    *f.MCPAllowMutations,
+				Store:             opStore,
+			}))
 			mcpListener, err = net.Listen("tcp", mcpServer.Addr)
 			if err != nil {
 				_ = managementListener.Close()
@@ -717,6 +713,21 @@ func loadKubeconfig(path string) (*rest.Config, error) {
 		return clientcmd.BuildConfigFromFlags("", path)
 	}
 	return ctrl.GetConfig()
+}
+
+// newMCPHTTPServer builds the MCP endpoint's http.Server. The MCP transport
+// is streamable HTTP: a standing GET carries the SSE stream and hanging POSTs
+// carry tool-call responses, both alive far longer than any request-read
+// budget — a ReadTimeout (or WriteTimeout) arms a whole-request deadline that
+// severs those streams mid-session. The server therefore bounds only the
+// request HEADERS (the slowloris guard) and leaves the bodies to the
+// protocol's own lifecycle.
+func newMCPHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler:           handler,
+	}
 }
 
 // newStorageBackend selects and constructs the operator's artifact store from

--- a/main_test.go
+++ b/main_test.go
@@ -1757,3 +1757,22 @@ func TestRun_ErrorBody_AllPathsCarryContentLengthHeader(t *testing.T) {
 		t.Errorf("Content-Length missing on 404; headers = %v", resp.Header)
 	}
 }
+
+// The MCP transport is streamable HTTP (standing GET SSE stream, hanging
+// POSTs); a whole-request read or write deadline severs those streams
+// mid-session. Only the header read may be bounded (slowloris guard).
+func TestNewMCPHTTPServer_BoundsOnlyHeaderRead(t *testing.T) {
+	srv := newMCPHTTPServer(":8084", http.NotFoundHandler())
+	if srv.ReadTimeout != 0 {
+		t.Errorf("ReadTimeout = %v, want 0 — a request-read deadline severs the standing MCP streams", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %v, want 0 — a write deadline severs the SSE stream", srv.WriteTimeout)
+	}
+	if srv.ReadHeaderTimeout <= 0 {
+		t.Error("ReadHeaderTimeout must be set as the slowloris guard")
+	}
+	if srv.Addr != ":8084" {
+		t.Errorf("Addr = %q", srv.Addr)
+	}
+}


### PR DESCRIPTION
… and MCP

- The S3 storage handler bounded the WHOLE GetObject stream (headers + body copy) with --storage-read-timeout (default 30s): any artifact streaming slower than that was silently truncated after 200 + Content-Length were on the wire, corrupting every consumer's fetch — while the local backend streams under the server's 5m write budget. ReadTimeout now bounds only the time to first byte; the body streams under the surrounding http.Server's write timeout, matching the local backend.

- The Publisher published artifacts every consumer refuses to fetch: with --max-artifact-bytes at its 0 default there was no size gate at all, but both in-house fetchers (jaas chaining, stageset) hard-cap extraction at 16 MiB per entry and 64 MiB aggregate — a snippet past those bounds went Ready=True permanently unfetchable. The consumer caps are now enforced unconditionally at publish (sources.DefaultMaxPerEntryBytes / DefaultMaxExtractedBytes, exported as the shared contract), surfacing as ArtifactTooLarge; the operator knob still tightens below them.

- Output=source published spec.files keys the consumers' extractor silently DROPS (bytes outside [A-Za-z0-9._/-], dot-prefixed segments) — the file just never arrived downstream. The webhook rejects such keys at admission for source-mode snippets and the Publisher enforces the same rule as the fallback (ErrUnsafeEntryName → InvalidSpec), both through the one exported sources.SafeEntryName check.

- The confined MCP importer searched --library-path roots LEFTMOST first; go-jsonnet's FileImporter iterates JPaths in reverse, so the same flags resolved collisions differently on the confined path than on the HTTP and stdio paths (whose rightmost-wins contract the flag help documents). The confined importer now searches rightmost first.

- The MCP http.Server reused the Jsonnet server's --read-timeout as a whole-request read deadline, severing the streamable-HTTP transport's standing GET SSE stream and hanging POSTs mid-session. The server now bounds only the request headers (slowloris guard) and leaves bodies to the protocol's lifecycle.

Every behavioral fix ships with tests confirmed failing on the pre-fix code: the slow-body stream arrives complete while the first-byte bound still fires, over-cap entries/totals and unsafe source names are refused (and safe ones still publish, the operator cap still tightens), rightmost root wins, and the MCP server shape is pinned.