### PR TITLE
fix: four low-severity defects across caches, storage, eval, and the …

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"runtime/debug"
 	"sync/atomic"
 	"time"
@@ -172,7 +173,15 @@ func evaluateWithDeadline(ctx context.Context, eval func() (string, error), time
 		// classifiable failure.
 		defer func() {
 			if r := recover(); r != nil {
-				ch <- result{err: fmt.Errorf("jsonnet evaluation panicked: %v\n%s", r, debug.Stack())}
+				// Log the goroutine stack server-side for diagnosis, but keep
+				// it OUT of the returned error: that error travels to the MCP
+				// network transport verbatim (minus library-path scrubbing),
+				// so embedding debug.Stack() would hand an unauthenticated
+				// caller the operator's internal stack. The caller gets only
+				// the panic value.
+				slog.Error("jsonnet evaluation panicked",
+					slog.Any("panic", r), slog.String("stack", string(debug.Stack())))
+				ch <- result{err: fmt.Errorf("jsonnet evaluation panicked: %v", r)}
 			}
 		}()
 		out, err := eval()

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -208,6 +208,12 @@ func TestEvaluateWithDeadline_PanicInGoroutineSurfacesAsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "panicked") {
 		t.Errorf("err = %v, want the 'panicked' marker so log readers can filter", err)
 	}
+	// The goroutine stack must NOT be in the returned error: it travels to the
+	// MCP network transport, so an internal stack would leak to unauthenticated
+	// callers. The stack is logged server-side instead.
+	if strings.Contains(err.Error(), ".go:") || strings.Contains(err.Error(), "goroutine ") {
+		t.Errorf("err leaks a stack trace to callers: %v", err)
+	}
 	if out != "" {
 		t.Errorf("out = %q, want empty on panic path", out)
 	}

--- a/internal/operator/clientcache.go
+++ b/internal/operator/clientcache.go
@@ -29,12 +29,12 @@ import (
 type tenantClientCache struct {
 	mu      sync.Mutex
 	entries map[string]tenantClientEntry
-	// epochs increments per key on every Forget. Get hands the caller the
-	// current epoch; Put writes only when it's unchanged, so a Forget
+	// gen is a single monotonic counter bumped on every Forget. Get hands the
+	// caller the current gen; Put writes only when it's unchanged, so a Forget
 	// landing between a concurrent Get-miss and its rebuild+Put can't be
 	// resurrected. Makes the cache correct at any MaxConcurrentReconciles,
 	// mirroring tokenCache and cycleCache.
-	epochs map[string]int64
+	gen int64
 }
 
 type tenantClientEntry struct {
@@ -43,12 +43,12 @@ type tenantClientEntry struct {
 }
 
 func newTenantClientCache() *tenantClientCache {
-	return &tenantClientCache{entries: map[string]tenantClientEntry{}, epochs: map[string]int64{}}
+	return &tenantClientCache{entries: map[string]tenantClientEntry{}}
 }
 
 // Get returns the cached client when one exists for key AND was built with
 // the supplied token. A token mismatch returns miss. The second return is
-// the key's current epoch, which the caller hands back to Put so a Forget
+// the current gen, which the caller hands back to Put so a Forget
 // in between drops the stale write.
 func (c *tenantClientCache) Get(key, token string) (client.Client, int64, bool) {
 	if c == nil {
@@ -56,16 +56,16 @@ func (c *tenantClientCache) Get(key, token string) (client.Client, int64, bool) 
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	epoch := c.epochs[key]
+	gen := c.gen
 	e, ok := c.entries[key]
 	if !ok || e.token != token {
-		return nil, epoch, false
+		return nil, gen, false
 	}
-	return e.client, epoch, true
+	return e.client, gen, true
 }
 
 // Put stores cl under key with the token it was built with, provided the
-// key's epoch hasn't moved since epochAtGet. A mismatch means a Forget
+// gen hasn't moved since epochAtGet. A mismatch means a Forget
 // evicted the entry mid-rebuild; the write is dropped. A subsequent
 // Get(key, token) returns cl until Forget evicts it or a different token
 // triggers a replace.
@@ -75,13 +75,13 @@ func (c *tenantClientCache) Put(key, token string, epochAtGet int64, cl client.C
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.epochs[key] != epochAtGet {
+	if c.gen != epochAtGet {
 		return
 	}
 	c.entries[key] = tenantClientEntry{token: token, client: cl}
 }
 
-// Forget evicts the cached client for key and bumps its epoch. Called from
+// Forget evicts the cached client for key and bumps gen. Called from
 // the finalizer path in lock-step with tokenCache.Forget so a re-created
 // snippet against the same SA mints a fresh token AND rebuilds the client
 // around it. nil-safe.
@@ -92,5 +92,5 @@ func (c *tenantClientCache) Forget(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.entries, key)
-	c.epochs[key]++
+	c.gen++
 }

--- a/internal/operator/cycle.go
+++ b/internal/operator/cycle.go
@@ -43,7 +43,11 @@ import (
 type cycleCache struct {
 	mu      sync.Mutex
 	entries map[types.UID]cycleVerdict
-	epochs  map[types.UID]int64
+	// gen is a single monotonic counter bumped on every Forget (see Store).
+	// A single counter rather than a per-UID map bounds memory under snippet
+	// churn: an unrelated snippet's Forget may make an in-flight walk re-walk,
+	// which is safe and cheap.
+	gen int64
 }
 
 type cycleVerdict struct {
@@ -55,7 +59,6 @@ type cycleVerdict struct {
 func newCycleCache() *cycleCache {
 	return &cycleCache{
 		entries: map[types.UID]cycleVerdict{},
-		epochs:  map[types.UID]int64{},
 	}
 }
 
@@ -71,7 +74,7 @@ func (c *cycleCache) Lookup(uid types.UID, generation int64) (cycleVerdict, int6
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	epoch := c.epochs[uid]
+	epoch := c.gen
 	v, ok := c.entries[uid]
 	if !ok || v.generation != generation {
 		return cycleVerdict{}, epoch, false
@@ -90,7 +93,7 @@ func (c *cycleCache) Store(uid types.UID, generation int64, epochAtLookup int64,
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.epochs[uid] != epochAtLookup {
+	if c.gen != epochAtLookup {
 		return false
 	}
 	c.entries[uid] = cycleVerdict{generation: generation, hasCycle: hasCycle, path: path}
@@ -108,7 +111,7 @@ func (c *cycleCache) Forget(uid types.UID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.entries, uid)
-	c.epochs[uid]++
+	c.gen++
 }
 
 // hasCycleSourceEdge reports whether snip carries any spec.sourceRef or

--- a/internal/operator/cyclecache_test.go
+++ b/internal/operator/cyclecache_test.go
@@ -8,6 +8,7 @@ package operator
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -373,5 +374,39 @@ func TestReconcile_CycleCachePopulatedOnFirstReconcile(t *testing.T) {
 	}.NamespacedName)
 	if v, _, ok := r.CycleCache.Lookup(snip.UID, snip.Generation); !ok || v.hasCycle {
 		t.Errorf("cycle cache not populated with no-cycle verdict: hit=%v verdict=%+v", ok, v)
+	}
+}
+
+// TestCycleCache_ForgetLeavesNoPerKeyState pins that churn does not leak: after
+// storing and forgetting many distinct UIDs, no per-key state remains. The
+// invalidation counter is a single scalar, not a per-key map, so a long-lived
+// operator processing a high volume of short-lived snippets does not grow the
+// cache without bound.
+func TestCycleCache_ForgetLeavesNoPerKeyState(t *testing.T) {
+	c := newCycleCache()
+	for i := range 1000 {
+		uid := types.UID(fmt.Sprintf("uid-%d", i))
+		c.Store(uid, 1, 0, false, "")
+		c.Forget(uid)
+	}
+	c.mu.Lock()
+	n := len(c.entries)
+	c.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("cache retains %d entries after forgetting every key; per-key state leaks", n)
+	}
+}
+
+// TestCycleCache_ForgetOfAnotherKeyDropsInFlightStore documents the deliberate
+// trade of the single-counter design: a Forget of ANY key invalidates every
+// in-flight walk's pending Store, so an unrelated snippet's deletion makes this
+// walk re-run. That is safe (the verdict is recomputed) and rare, and it is the
+// price of bounding the cache to O(live snippets) rather than O(ever-seen).
+func TestCycleCache_ForgetOfAnotherKeyDropsInFlightStore(t *testing.T) {
+	c := newCycleCache()
+	_, gen, _ := c.Lookup("uid-a", 1) // start walking A
+	c.Forget("uid-b")                 // an unrelated snippet is deleted mid-walk
+	if c.Store("uid-a", 1, gen, false, "no cycle") {
+		t.Error("Store wrote despite a concurrent Forget of another key; expected a safe re-walk")
 	}
 }

--- a/internal/operator/token.go
+++ b/internal/operator/token.go
@@ -83,14 +83,16 @@ type tokenCache struct {
 	mu     sync.Mutex
 	tokens map[string]cachedToken
 
-	// epochs increments per key on every Forget. A Mint captures the
-	// key's epoch before calling the apiserver and drops its cache write
-	// if the epoch moved in the meantime — so a Forget landing between a
-	// concurrent Mint completing and its write can't be silently
-	// resurrected. Without this the cache is only correct while reconciles
-	// serialize (MaxConcurrentReconciles == 1); the guard makes it correct
-	// at any concurrency, mirroring cycleCache.
-	epochs map[string]int64
+	// gen is a single monotonic counter bumped on every Forget. A Mint
+	// captures gen before calling the apiserver and drops its cache write if
+	// gen moved in the meantime — so a Forget landing between a concurrent
+	// Mint completing and its write can't be silently resurrected. Without
+	// this the cache is only correct while reconciles serialize
+	// (MaxConcurrentReconciles == 1); the guard makes it correct at any
+	// concurrency, mirroring cycleCache. A single counter (rather than a
+	// per-key map) bounds memory: an unrelated key's Forget may make an
+	// in-flight Mint re-mint, which is safe and rare.
+	gen int64
 
 	// flight dedupes concurrent Mint calls for the same key. The first
 	// caller wins; subsequent callers wait and observe the cached result.
@@ -106,7 +108,6 @@ func newTokenCache(minter tokenMinter) *tokenCache {
 		refreshMargin: defaultTokenMargin,
 		now:           time.Now,
 		tokens:        map[string]cachedToken{},
-		epochs:        map[string]int64{},
 	}
 }
 
@@ -133,7 +134,7 @@ func (c *tokenCache) Token(ctx context.Context, namespace, serviceAccount string
 		// write below drops the entry rather than resurrecting a token
 		// the deletion path intended to evict.
 		c.mu.Lock()
-		epochAtMint := c.epochs[key]
+		genAtMint := c.gen
 		c.mu.Unlock()
 		// Detach the mint from the first caller's ctx. singleflight
 		// returns the same (result, err) pair to every waiter, so a
@@ -158,7 +159,7 @@ func (c *tokenCache) Token(ctx context.Context, namespace, serviceAccount string
 			return "", err
 		}
 		c.mu.Lock()
-		if c.epochs[key] == epochAtMint {
+		if c.gen == genAtMint {
 			margin := c.refreshMarginFor(expires)
 			c.tokens[key] = cachedToken{token: token, expires: expires, refreshAt: expires.Add(-margin)}
 		}
@@ -217,5 +218,5 @@ func (c *tokenCache) Forget(namespace, serviceAccount string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.tokens, key)
-	c.epochs[key]++
+	c.gen++
 }

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -247,7 +247,13 @@ func New() *Fetcher {
 		Control:   f.controlConn,
 	}).DialContext
 	f.HTTPClient = &http.Client{
-		Timeout:       30 * time.Second,
+		// A total-request budget generous enough to stream the largest
+		// artifact the fetcher will accept: the 64 MiB decompressed cap
+		// (defaultMaxArchiveBytes) needs more than a 30s wall clock over a
+		// slow link. Matches the stageset fetcher's 5m budget for the same
+		// ExternalArtifact contract; the byte caps, not this timeout, bound
+		// what a malicious source can stream.
+		Timeout:       5 * time.Minute,
 		CheckRedirect: f.checkRedirect,
 		Transport:     transport,
 	}

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -1177,6 +1177,20 @@ func TestNew_TransportHasNoProxy(t *testing.T) {
 	}
 }
 
+// New()'s total-request timeout must be generous enough to stream the largest
+// artifact the fetcher accepts (64 MiB), matching the stageset fetcher's budget
+// for the same ExternalArtifact contract. A 30s budget starved a slow-link
+// download well within the byte cap.
+func TestNew_TotalTimeoutFitsMaxArchive(t *testing.T) {
+	f := New()
+	if f.HTTPClient == nil {
+		t.Fatal("New(): HTTPClient not set")
+	}
+	if f.HTTPClient.Timeout < 5*time.Minute {
+		t.Errorf("HTTPClient.Timeout = %s, want >= 5m so a 64 MiB artifact fits over a slow link", f.HTTPClient.Timeout)
+	}
+}
+
 func TestNew_InstallsCheckRedirect_ValidatesEveryHop(t *testing.T) {
 	f := New()
 	if f.HTTPClient == nil || f.HTTPClient.CheckRedirect == nil {

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -156,6 +156,21 @@ func (s *Store) Put(_ context.Context, namespace, name, revision string, entries
 	finalRel := filepath.Join(dir, RevisionFilename(revision))
 	tmpRel := finalRel + ".tmp"
 
+	// A revision is content-addressed: the same revision means byte-identical
+	// tarball bytes (deterministic entry ordering + zero ModTime). If it is
+	// already on disk, rewriting it would only re-stamp its mtime — which
+	// keeps advancing the "newest revision" boundary Prune anchors its grace
+	// window on, so a just-evicted revision's grace never elapses and it is
+	// never collected. Skip the write and re-derive the Result from the
+	// existing file, leaving its mtime untouched.
+	if info, statErr := s.fs.Stat(finalRel); statErr == nil && !info.IsDir() {
+		digest, err := s.digestOf(finalRel)
+		if err != nil {
+			return Result{}, err
+		}
+		return Result{Path: finalRel, SizeBytes: info.Size(), DigestSHA256: digest}, nil
+	}
+
 	digest, size, err := s.writeTarGz(tmpRel, entries)
 	if err != nil {
 		_ = s.fs.Remove(tmpRel)
@@ -196,6 +211,22 @@ func (s *Store) Open(_ context.Context, namespace, name, revision string) (io.Re
 		return nil, fmt.Errorf("storage: open %q: %w", rel, err)
 	}
 	return f, nil
+}
+
+// digestOf returns the hex SHA-256 of an already-stored tarball, read through
+// the same traversal-guarded FS view as the HTTP handler. Used when Put finds
+// the revision already on disk and re-derives the Result without rewriting.
+func (s *Store) digestOf(relPath string) (string, error) {
+	f, err := s.fs.FS().Open(filepath.ToSlash(relPath))
+	if err != nil {
+		return "", fmt.Errorf("storage: open %q: %w", relPath, err)
+	}
+	defer f.Close()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, f); err != nil {
+		return "", fmt.Errorf("storage: hash %q: %w", relPath, err)
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 func (s *Store) writeTarGz(relPath string, entries []FileEntry) (string, int64, error) {

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -161,18 +161,51 @@ func TestPut_DigestIsIndependentOfFileOrder(t *testing.T) {
 	}
 }
 
-func TestPut_OverwritesPreviousFileAtSameRevision(t *testing.T) {
+// A revision is content-addressed, so re-Putting the same revision is a no-op on
+// disk: the file is NOT rewritten and its mtime is preserved. Re-stamping the
+// mtime would keep advancing the "newest revision" boundary Prune anchors its
+// grace window on, so a just-evicted revision would never be collected while
+// GCGrace > 0. Put still returns the correct Result derived from the existing
+// file.
+func TestPut_SameRevisionIsIdempotentAndPreservesMtime(t *testing.T) {
 	s := newTestStore(t)
-	if _, err := s.Put(context.Background(), "ns", "n", "r", []FileEntry{{Path: "f", Content: []byte("v1")}}); err != nil {
-		t.Fatal(err)
-	}
-	got, err := s.Put(context.Background(), "ns", "n", "r", []FileEntry{{Path: "f", Content: []byte("v2")}})
+	entries := []FileEntry{{Path: "f", Content: []byte("v1")}}
+
+	first, err := s.Put(context.Background(), "ns", "n", "r", entries)
 	if err != nil {
 		t.Fatal(err)
 	}
-	members := readTarMembers(t, s.fs.Name(), got.Path)
-	if members["f"] != "v2" {
-		t.Errorf("got %q, want overwrite with v2", members["f"])
+	path := filepath.Join(s.fs.Name(), first.Path)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after first Put: %v", err)
+	}
+
+	// Age the file so a rewrite would move the mtime forward observably.
+	old := before.ModTime().Add(-time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	second, err := s.Put(context.Background(), "ns", "n", "r", entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after second Put: %v", err)
+	}
+	if !after.ModTime().Equal(old) {
+		t.Errorf("mtime moved on a same-revision re-Put (%v -> %v); the file was rewritten", old, after.ModTime())
+	}
+	// The Result is still correct — same digest and size as the first Put.
+	if second.DigestSHA256 != first.DigestSHA256 || second.SizeBytes != first.SizeBytes {
+		t.Errorf("re-Put Result = (%s, %d), want (%s, %d)", second.DigestSHA256, second.SizeBytes, first.DigestSHA256, first.SizeBytes)
+	}
+	// Content is intact.
+	if m := readTarMembers(t, s.fs.Name(), second.Path); m["f"] != "v1" {
+		t.Errorf("content = %q, want v1", m["f"])
 	}
 }
 


### PR DESCRIPTION
…fetcher

- The per-key epoch maps in cycleCache, tokenCache, and tenantClientCache grew without bound: Forget deleted the value but the epoch counter entry was never removed, so a long-lived operator processing a high volume of short-lived snippets leaked one map entry per ever-seen key. Each cache now uses a single monotonic gen counter instead of a per-key epoch map — the same invalidation guard (a Forget between a Lookup/mint and its Store drops the stale write), now O(live keys) memory. The trade is that an unrelated key's Forget can make an in-flight compute re-run, which is safe and rare.

- A steady republish rewrote the revision's tarball every interval, re-stamping its mtime — which kept advancing the "newest revision" boundary Prune anchors its grace window on, so a just-evicted revision was never collected while GCGrace > 0. A revision is content-addressed (same revision means byte-identical bytes), so Put now skips the write when the revision is already on disk and re-derives the Result from the existing file, leaving its mtime untouched.

- The go-jsonnet panic recovery embedded debug.Stack() in the returned error, which reaches the MCP network transport verbatim — handing an unauthenticated caller the operator's internal goroutine stack. The stack is now logged server-side; the returned error carries only the panic value.

- The source fetcher's HTTP client used a 30s total-request timeout, too short to stream the 64 MiB artifact its own cap allows over a slow link. Raised to 5m, matching the stageset fetcher's budget for the same ExternalArtifact contract; the byte caps, not the timeout, bound what a source can stream.

Tests confirmed failing on the pre-fix code: same-revision Put preserves the mtime, the panic error carries no stack, the fetcher timeout fits the cap, and a cross-key Forget invalidates an in-flight cache write (with no per-key state left after churn).