### PR TITLE
ci: adopt the metio/ci policy-check gate

### DIFF
--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -27,6 +27,7 @@ jobs:
   validate:
     name: Render dashboards against grafonnet
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -54,6 +55,7 @@ jobs:
     needs: validate
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write # push the image to ghcr.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,7 @@ permissions:
 jobs:
   website:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     env:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,6 +19,7 @@ jobs:
     # Enumerate every Fuzz* target as a {pkg, func} pair so new targets are
     # fuzzed automatically — no hand-maintained matrix to drift.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       matrix: ${{ steps.list.outputs.matrix }}
     steps:
@@ -37,7 +38,9 @@ jobs:
     # permanent seed (it then reproduces deterministically in the Verify gate).
     needs: discover
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Must comfortably exceed the fuzztime input: the dispatch description
+    # suggests campaigns up to 1h per target, plus setup-go/envtest overhead.
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
@@ -75,6 +78,7 @@ jobs:
     needs: [discover, fuzz]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Verify every job succeeded or skipped
         env:

--- a/.github/workflows/kind-smoke.yml
+++ b/.github/workflows/kind-smoke.yml
@@ -38,6 +38,7 @@ jobs:
   discover:
     name: Discover chart + test versions
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       chart_version: ${{ steps.find.outputs.version }}
       k8s_versions: ${{ steps.versions.outputs.k8s }}
@@ -52,6 +53,10 @@ jobs:
           fetch-depth: 0
       - id: scope
         name: Did this PR touch operator code, dependencies, or smoke scripts?
+        env:
+          # Attacker-influenced event data must reach the shell via env:, not
+          # via ${{ }} expansion inside run:.
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           # Replaces the old `paths:` trigger: the heavy kind jobs run only when
           # something they exercise changed. go.mod/go.sum count because a
@@ -61,7 +66,7 @@ jobs:
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          base="${{ github.event.pull_request.base.sha }}"
+          base="$BASE_SHA"
           if git diff --name-only "$base" HEAD | grep -qE \
                '^(api|config)/|^internal/(operator|storage|sources|webhook)/|^main\.go$|^Dockerfile$|^hack/smoke/|^\.github/workflows/kind-smoke\.yml$|^go\.(mod|sum)$'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
@@ -133,6 +138,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       # Swept across the newest Kubernetes × Flux versions the discover job
@@ -216,6 +222,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -275,6 +282,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -331,6 +339,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -391,6 +400,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -455,6 +465,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -526,6 +537,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -598,6 +610,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -671,6 +684,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -727,6 +741,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -797,6 +812,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -888,6 +904,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.chart_version != '' && needs.discover.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -980,6 +997,7 @@ jobs:
       - servicemesh
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Fail unless every dependency succeeded or was skipped
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+# Least-privilege default; the container and github jobs raise their own
+# job-level permissions (packages/contents/id-token) as needed.
+permissions:
+  contents: read
 # Serialize release runs. Each run's release-notes lower bound is the latest tag
 # at the time its prepare job runs; two merges in quick succession would both
 # read that bound before either run has tagged, producing overlapping notes.
@@ -18,6 +22,7 @@ jobs:
   prepare:
     name: Prepare Release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       needed: ${{ steps.gate.outputs.needed }}
       version: ${{ steps.version.outputs.version }}
@@ -41,6 +46,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.needed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         # The six linux architectures the container image ships (the set
@@ -86,7 +92,7 @@ jobs:
           ver="${{ needs.prepare.outputs.version }}"
           os="${{ matrix.goos }}"
           arch="${{ matrix.goarch }}"
-          name="${{ github.event.repository.name }}"
+          name="$REPO_NAME"
           ext=""
           [ "$os" = windows ] && ext=".exe"
           go build -o "${name}_v${ver}${ext}" -trimpath \
@@ -101,6 +107,8 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
+          # Event data must reach the shell via env:, not ${{ }} inside run:.
+          REPO_NAME: ${{ github.event.repository.name }}
       - name: Upload Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -114,6 +122,7 @@ jobs:
     needs: [prepare, build]
     if: needs.prepare.outputs.needed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write # cosign keyless image signing
       contents: read
@@ -135,6 +144,7 @@ jobs:
     needs: [prepare, build, container]
     if: needs.prepare.outputs.needed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # create the GitHub Release
       id-token: write # cosign keyless sign-blob (Fulcio OIDC)

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,16 +17,19 @@ jobs:
     uses: metio/ci/.github/workflows/golang.yml@392a32762cd5626c0aa9e6e67414240a021b90ae # 2026.6.26153329
   reuse:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6
   yaml:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: pipx install yamllint && yamllint .
   github-actions:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
@@ -35,6 +38,7 @@ jobs:
           filter_mode: nofilter
   markdown:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23
@@ -42,6 +46,7 @@ jobs:
           globs: "**/*.md"
   typos:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1
@@ -50,6 +55,7 @@ jobs:
     # the published package. Fails on error-level findings (naming/branding);
     # inclusive-language findings are warning-level and only annotate.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # 2.1.2 # renovate: pin to a SHA
@@ -62,6 +68,7 @@ jobs:
     # tools pre-staged in dev/Containerfile. Versions are kept in lockstep with
     # that Containerfile so local and CI runs agree.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       # renovate: datasource=github-releases depName=wjdp/htmltest
       HTMLTEST_VERSION: 0.17.0
@@ -106,6 +113,7 @@ jobs:
           ( cd docs/themes/metio && "${RUNNER_TEMP}/biome" lint )
   container-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - id: buildx
@@ -138,6 +146,7 @@ jobs:
     # a skipped job still satisfies the all-green gate below.
     if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -161,13 +170,23 @@ jobs:
             fi
           done
           exit $status
+  policy:
+    # metio org workflow conventions (conftest/Rego from metio/ci): SHA-pinned
+    # uses refs, top-level permissions, timeout-minutes on every job, no
+    # untrusted ${{ github.event.* }} interpolation in run: blocks.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: metio/ci/policy-check@afbf10fe3c5ceb438a1da090e78cc6c0159c4754 # 2026.7.5093733
   verify:
     # Single required check covering every job above: mark only this one
     # required in branch protection and new jobs are covered automatically.
     name: Verify
-    needs: [go, reuse, yaml, github-actions, markdown, typos, prose, docs-lint, container-image, dco]
+    needs: [go, reuse, yaml, github-actions, markdown, typos, prose, docs-lint, container-image, dco, policy]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Verify every job succeeded or skipped
         env:


### PR DESCRIPTION
The gate runs the org's conftest/Rego conventions over the workflows: SHA-pinned uses refs, top-level permissions, timeout-minutes on every job, and no untrusted github.event interpolation in run blocks. Every job now declares timeout-minutes, release.yml gained a top-level least-privilege permissions block, and the two run steps expanding github.event data inline now receive it via env. The policy job is wired into the Verify all-green aggregate's needs list.