### PR TITLE
fix(flake): print the devshell menu only for an interactive shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,11 +142,17 @@
           default = pkgs.mkShell {
             KUBEBUILDER_ASSETS = "${kubebuilder-assets}";
             packages = goTools ++ docsTools ++ lintTools ++ (with pkgs; [ jq ]);
+            # Only print the menu for an interactive shell — otherwise it lands
+            # on the stdout that `nix develop --command <tool>` captures (e.g.
+            # golang.yml's `unformatted="$(… gofumpt -l .)"`), and the menu text
+            # reads as tool output.
             shellHook = ''
-              echo "jaas devshell — go + static suite (staticcheck, gofumpt, gosec,"
-              echo "  govulncheck, arch-go, modernize), envtest assets wired, plus the"
-              echo "  docs/dashboards tools (jsonnet, hugo, htmltest, biome, vale,"
-              echo "  helm-schema) and the lint gate. Run gates via nix develop --command."
+              if [ -t 1 ]; then
+                echo "jaas devshell — go + static suite (staticcheck, gofumpt, gosec,"
+                echo "  govulncheck, arch-go, modernize), envtest assets wired, plus the"
+                echo "  docs/dashboards tools (jsonnet, hugo, htmltest, biome, vale,"
+                echo "  helm-schema) and the lint gate. Run gates via nix develop --command."
+              fi
             '';
           };
         }


### PR DESCRIPTION
`nix develop --command <tool>` runs the shellHook first, so the menu echoed to stdout would be captured by golang.yml's gofumpt gate (`unformatted="$(… gofumpt -l .)"`) and read as unformatted files once the golang.yml pin moves to the flake-only reusable workflow. Gate the menu on `[ -t 1 ]` so it shows interactively but never pollutes captured command output.