### PR TITLE
chore(nix): source the shared devShell from metio/nix-devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,21 @@
 {
   "nodes": {
-    "ci": {
+    "devshell": {
       "inputs": {
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783323959,
-        "narHash": "sha256-eMGddB++ciRjkED1jTD34SKA7/BYGDFRWiznaNHrsbM=",
+        "lastModified": 1783367782,
+        "narHash": "sha256-7/6160miyw7UATMxGFo+ZKUB2VC6dVFjAAYI3rM6D8c=",
         "owner": "metio",
-        "repo": "ci",
-        "rev": "84b9ffe3e7a023be8335f28eb3aa6a8c6cb13cf0",
+        "repo": "nix-devshell",
+        "rev": "9bbba31438253f49b9a9f9c5dde4caf74db81e99",
         "type": "github"
       },
       "original": {
         "owner": "metio",
-        "repo": "ci",
+        "repo": "nix-devshell",
         "type": "github"
       }
     },
@@ -52,13 +52,13 @@
     },
     "root": {
       "inputs": {
-        "ci": "ci",
+        "devshell": "devshell",
         "flake-compat": [
-          "ci",
+          "devshell",
           "flake-compat"
         ],
         "nixpkgs": [
-          "ci",
+          "devshell",
           "nixpkgs"
         ]
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,16 +15,16 @@
   description = "jaas development environment";
 
   inputs = {
-    ci.url = "github:metio/ci";
-    nixpkgs.follows = "ci/nixpkgs";
-    flake-compat.follows = "ci/flake-compat";
+    devshell.url = "github:metio/nix-devshell";
+    nixpkgs.follows = "devshell/nixpkgs";
+    flake-compat.follows = "devshell/flake-compat";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      ci,
+      devshell,
       ...
     }:
     let
@@ -47,8 +47,8 @@
           goTools = [
             pkgs.go
             pkgs.go-tools # staticcheck
-            (ci.lib.arch-go pkgs)
-            (ci.lib.modernize pkgs)
+            (devshell.lib.arch-go pkgs)
+            (devshell.lib.modernize pkgs)
           ]
           ++ (with pkgs; [
             gofumpt
@@ -61,7 +61,7 @@
           # helm-schema (from metio/ci) builds the chart values reference; cosign
           # keyless-signs the pushed dashboard image (dashboards.yml).
           docsTools = [
-            (ci.lib.helm-schema pkgs)
+            (devshell.lib.helm-schema pkgs)
           ]
           ++ (with pkgs; [
             go-jsonnet
@@ -74,13 +74,13 @@
           ]);
         in
         {
-          default = ci.lib.mkDevShell {
+          default = devshell.lib.mkDevShell {
             inherit pkgs;
             packages = goTools ++ docsTools ++ (with pkgs; [ jq ]);
             # controller-runtime envtest wants a dir holding etcd, kube-apiserver,
             # and kubectl; the shared flake assembles it from nixpkgs, so the
             # assets are hermetic and offline instead of downloaded.
-            env.KUBEBUILDER_ASSETS = "${ci.lib.kubebuilderAssets pkgs}";
+            env.KUBEBUILDER_ASSETS = "${devshell.lib.kubebuilderAssets pkgs}";
             menu = ''
               echo "jaas — go + static suite (staticcheck, gofumpt, gosec, govulncheck,"
               echo "  arch-go, modernize), envtest assets wired, plus the docs/dashboards"


### PR DESCRIPTION
The shared flake moved into metio/nix-devshell. Repoints the flake input `ci` → `devshell` (github:metio/nix-devshell) and every `ci.lib.*` (mkDevShell, arch-go, modernize, helm-schema, kubebuilderAssets) → `devshell.lib.*`; nixpkgs + flake-compat follow the same shared pin, now via `devshell/*`. Action and reusable-workflow refs are untouched.