### PR TITLE
chore: drop the repo-level funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: The jaas Authors
-# SPDX-License-Identifier: 0BSD
-
-github:
-  - metio
-  - sebhoss


### PR DESCRIPTION
The org-wide .github/FUNDING.yml now covers every metio repository. A repo-level file overrides the org default rather than merging with it, so keeping this one would pin the repo to a copy that drifts as the org's changes.