### PR TITLE
ci(typos): exclude go.mod from the typos scan

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -13,7 +13,10 @@ mis = "mis"
 pn = "pn"
 
 [files]
-# docs/themes/metio is a separate (CC0) submodule with its own CI; CI's checkout
-# doesn't fetch submodules, so exclude it here too — otherwise a local run flags
-# the theme's content while CI never sees it.
-extend-exclude = ["LICENSES/", "go.sum", "docs/themes/"]
+# go.mod/go.sum are machine-generated dependency manifests: their module pins carry
+# git SHAs whose hex fragments read as words (afe→safe, dead, cafe, …), and a real
+# module-path typo fails the build rather than reaching typos. docs/themes/metio is a
+# separate (CC0) submodule with its own CI; CI's checkout doesn't fetch submodules, so
+# exclude it here too — otherwise a local run flags the theme's content while CI never
+# sees it.
+extend-exclude = ["LICENSES/", "go.mod", "go.sum", "docs/themes/"]


### PR DESCRIPTION
Mirrors the stageset-controller change: a dependency pseudo-version's git SHA can read as a word (…-afe73141d399 → "afe"→"safe"), tripping typos on go.mod the same way go.sum already did. Both are generated dependency manifests whose real errors fail the build, so exclude go.mod too. Keeps the typos config identical across the two repos.