### PR TITLE
fix(operator): never crash-loop on a missing CRD or incomplete RBAC

### DIFF
--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -15,17 +15,22 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	jaasv1 "github.com/metio/jaas/api/v1"
 	"github.com/metio/jaas/internal/sources"
+	"github.com/metio/jaas/internal/startupcheck"
 )
 
 // GracefulShutdownTimeout bounds how long the manager waits for in-flight
@@ -64,9 +69,21 @@ func (r *readinessSignal) Start(ctx context.Context) error {
 	return nil
 }
 
+// cacheSyncTimeout is effectively unbounded: a controller-runtime controller
+// treats a source that does not sync within this window as fatal and exits the
+// process, so the default (2m) turns a missing CRD or an incomplete operator
+// ClusterRole into a crash-loop. Waiting indefinitely instead keeps the pod alive
+// and retrying the informer, so the failure degrades to "not ready, waiting" (see
+// internal/startupcheck for the actionable log; readinessSignal keeps the pod
+// NotReady) and self-heals the moment the CRD is installed or the RBAC is granted
+// — no restart. In a healthy cluster the caches sync in well under a second.
+const cacheSyncTimeout = 100 * 365 * 24 * time.Hour
+
 var defaultBuilder builder = func(restCfg *rest.Config, opts ctrl.Options, cfg Config) (runner, error) {
 	if cfg.SkipControllerNameValidation {
-		opts.Controller = ctrlconfig.Controller{SkipNameValidation: new(true)}
+		// Set the field rather than replacing the struct, so the caller's
+		// CacheSyncTimeout (set in runWithBuilder) survives.
+		opts.Controller.SkipNameValidation = new(true)
 	}
 	if cfg.EnableWebhook {
 		port := cfg.WebhookPort
@@ -202,6 +219,10 @@ func runWithBuilder(ctx context.Context, cfg Config, restCfg *rest.Config, build
 	}
 
 	opts := ctrl.Options{Scheme: scheme, GracefulShutdownTimeout: new(GracefulShutdownTimeout)}
+	// Never let a controller exit the process because a source could not sync — a
+	// missing CRD or an incomplete ClusterRole degrades to "not ready, waiting",
+	// not a crash-loop. See cacheSyncTimeout.
+	opts.Controller.CacheSyncTimeout = cacheSyncTimeout
 	if cfg.MetricsBindAddress != "" {
 		opts.Metrics = metricsserver.Options{BindAddress: cfg.MetricsBindAddress}
 	}
@@ -261,8 +282,54 @@ func runWithBuilder(ctx context.Context, cfg Config, restCfg *rest.Config, build
 		slog.Int("rerenderBurst", cfg.RerenderBurst),
 		slog.Int("extVarCount", len(cfg.ExtVars)))
 
+	// Diagnose an un-syncable watch out of band: if a watched CRD is missing or
+	// the ClusterRole can't list/watch it, log one actionable line per resource
+	// until the prerequisite appears. The manager retries the informer meanwhile
+	// (cacheSyncTimeout), so this never gates startup — it only explains the wait,
+	// turning raw reflector "forbidden" spam into a clear cause.
+	startupPreflight(ctx, restCfg, logger)
+
 	// OnReady (the pod's readiness flip) is wired by the builder as a
 	// non-leader-election runnable, so it fires after cache sync on every
 	// replica — leader or not. See readinessSignal.
 	return mgr.Start(ctx)
+}
+
+// startupPreflight launches the watch-prerequisite logger. It builds its own
+// discovery-backed RESTMapper and authorization client (the manager's are not
+// reachable through the runner seam) and returns immediately; the check loops in
+// a goroutine until every watched CRD is installed and permitted or ctx ends.
+func startupPreflight(ctx context.Context, restCfg *rest.Config, logger *slog.Logger) {
+	// A config with no apiserver host is a unit test's empty rest.Config, not a
+	// real cluster; skip the check rather than spin a goroutine that can never
+	// reach discovery. In-cluster and kubeconfig-derived configs always set Host.
+	if restCfg.Host == "" {
+		return
+	}
+	dc, err := discovery.NewDiscoveryClientForConfig(restCfg)
+	if err != nil {
+		logger.Error("startup preflight disabled: cannot build discovery client", slog.Any("error", err))
+		return
+	}
+	authz, err := authorizationv1client.NewForConfig(restCfg)
+	if err != nil {
+		logger.Error("startup preflight disabled: cannot build authorization client", slog.Any("error", err))
+		return
+	}
+	checker := &startupcheck.Checker{
+		Mapper: restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc)),
+		Review: authz.SelfSubjectAccessReviews(),
+		Logger: logger,
+	}
+	go checker.LogUntilReady(ctx, watchedResources(), 30*time.Second)
+}
+
+// watchedResources are the CRDs the operator keeps informers on. A missing or
+// unreadable one is what the preflight names.
+func watchedResources() []startupcheck.Target {
+	const group = "jaas.metio.wtf"
+	return []startupcheck.Target{
+		{GVK: schema.GroupVersionKind{Group: group, Version: "v1", Kind: "JsonnetSnippet"}, Group: group, Resource: "jsonnetsnippets"},
+		{GVK: schema.GroupVersionKind{Group: group, Version: "v1", Kind: "JsonnetLibrary"}, Group: group, Resource: "jsonnetlibraries"},
+	}
 }

--- a/internal/operator/manager_test.go
+++ b/internal/operator/manager_test.go
@@ -153,6 +153,27 @@ func TestRunWithBuilder_PassesSchemeAndContext(t *testing.T) {
 	}
 }
 
+// TestRunWithBuilder_SetsUnboundedCacheSyncTimeout pins the crash-loop guard: a
+// controller whose informer cannot sync (missing CRD / RBAC) must wait
+// indefinitely and keep the pod alive, not hit the 2m default and exit.
+func TestRunWithBuilder_SetsUnboundedCacheSyncTimeout(t *testing.T) {
+	var seenOpts ctrl.Options
+	build := func(_ *rest.Config, opts ctrl.Options, _ Config) (runner, error) {
+		seenOpts = opts
+		return &fakeRunner{}, nil
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := runWithBuilder(t.Context(), Config{Logger: logger}, &rest.Config{}, build); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seenOpts.Controller.CacheSyncTimeout != cacheSyncTimeout {
+		t.Errorf("CacheSyncTimeout = %s, want %s", seenOpts.Controller.CacheSyncTimeout, cacheSyncTimeout)
+	}
+	if seenOpts.Controller.CacheSyncTimeout < 365*24*time.Hour {
+		t.Errorf("CacheSyncTimeout = %s, want effectively unbounded (>= 1 year)", seenOpts.Controller.CacheSyncTimeout)
+	}
+}
+
 func TestRunWithBuilder_PropagatesLabelSelector(t *testing.T) {
 	var seenOpts ctrl.Options
 	fake := &fakeRunner{}

--- a/internal/startupcheck/startupcheck.go
+++ b/internal/startupcheck/startupcheck.go
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: The jaas Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+// Package startupcheck reports, at boot, which of the operator's watched
+// resources are not yet reconcilable — a CRD that is not installed, or one the
+// operator ServiceAccount may not list/watch. It only logs: the manager's large
+// cache-sync timeout is what keeps the process alive and retrying, so a missing
+// CRD or an incomplete ClusterRole degrades to "not ready, waiting" instead of a
+// crash-loop, and self-heals the moment the prerequisite appears. This turns the
+// raw client-go reflector "forbidden" spam into one clear, actionable line.
+package startupcheck
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Target is a resource the manager watches. Group/Resource address the
+// SelfSubjectAccessReview; GVK resolves the CRD through the RESTMapper.
+type Target struct {
+	GVK      schema.GroupVersionKind
+	Group    string
+	Resource string
+}
+
+// Problem is an unmet watch prerequisite.
+type Problem struct {
+	Target Target
+	Reason string
+}
+
+// AccessReviewer creates SelfSubjectAccessReviews — satisfied by
+// client-go's authorizationv1 SelfSubjectAccessReviewInterface.
+type AccessReviewer interface {
+	Create(ctx context.Context, sar *authorizationv1.SelfSubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SelfSubjectAccessReview, error)
+}
+
+// Checker verifies watch prerequisites against the live cluster.
+type Checker struct {
+	Mapper apimeta.RESTMapper
+	Review AccessReviewer
+	Logger *slog.Logger
+}
+
+// verbs the operator needs on each watched resource to run its informer.
+var requiredVerbs = []string{"list", "watch"}
+
+// Check returns the unmet prerequisites among targets: a CRD the RESTMapper
+// cannot resolve (not installed) or a resource the operator SA may not
+// list/watch (RBAC). An access-review API error is reported rather than assumed
+// allowed, so a transient failure surfaces instead of hiding a real gap.
+func (c *Checker) Check(ctx context.Context, targets []Target) []Problem {
+	// A DeferredDiscoveryRESTMapper caches misses, so a CRD installed after boot
+	// stays invisible until the cache is dropped.
+	if resetter, ok := c.Mapper.(interface{ Reset() }); ok {
+		resetter.Reset()
+	}
+	var problems []Problem
+	for _, t := range targets {
+		if _, err := c.Mapper.RESTMapping(t.GVK.GroupKind(), t.GVK.Version); err != nil {
+			problems = append(problems, Problem{Target: t, Reason: "CRD is not installed"})
+			continue
+		}
+		if reason := c.reviewAccess(ctx, t); reason != "" {
+			problems = append(problems, Problem{Target: t, Reason: reason})
+		}
+	}
+	return problems
+}
+
+func (c *Checker) reviewAccess(ctx context.Context, t Target) string {
+	for _, verb := range requiredVerbs {
+		review := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Group:    t.Group,
+					Resource: t.Resource,
+					Verb:     verb,
+				},
+			},
+		}
+		resp, err := c.Review.Create(ctx, review, metav1.CreateOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			// The authorization API itself is unavailable — cannot judge; skip.
+			return ""
+		case err != nil:
+			return "cannot check RBAC (" + verb + "): " + err.Error()
+		case !resp.Status.Allowed:
+			return "operator ServiceAccount may not " + verb + " it — grant list+watch in the operator ClusterRole"
+		}
+	}
+	return ""
+}
+
+// LogUntilReady polls Check every interval, logging one clear WARN per unmet
+// prerequisite, until all are met (or ctx is cancelled). It returns without
+// error either way — it is diagnostic, never a gate. The first all-clear pass
+// logs an INFO so the recovery is visible in the log.
+func (c *Checker) LogUntilReady(ctx context.Context, targets []Target, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	warned := false
+	for {
+		problems := c.Check(ctx, targets)
+		if len(problems) == 0 {
+			if warned {
+				c.Logger.Info("all watched resources are now installed and permitted; reconciliation can proceed")
+			}
+			return
+		}
+		warned = true
+		for _, p := range problems {
+			c.Logger.Warn("waiting for a watched resource before reconciling",
+				"resource", p.Target.Resource+"."+p.Target.Group,
+				"reason", p.Reason)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/startupcheck/startupcheck_test.go
+++ b/internal/startupcheck/startupcheck_test.go
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: The jaas Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package startupcheck
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var snippetGVK = schema.GroupVersionKind{Group: "jaas.metio.wtf", Version: "v1", Kind: "JsonnetSnippet"}
+
+func target() Target {
+	return Target{GVK: snippetGVK, Group: "jaas.metio.wtf", Resource: "jsonnetsnippets"}
+}
+
+// mapperWith builds a RESTMapper that resolves only the listed GVKs; anything
+// else returns a no-match error, standing in for an uninstalled CRD.
+func mapperWith(gvks ...schema.GroupVersionKind) apimeta.RESTMapper {
+	m := apimeta.NewDefaultRESTMapper(nil)
+	for _, gvk := range gvks {
+		m.Add(gvk, apimeta.RESTScopeNamespace)
+	}
+	return m
+}
+
+type fakeReviewer struct {
+	allowed bool
+	err     error
+}
+
+func (f fakeReviewer) Create(_ context.Context, sar *authorizationv1.SelfSubjectAccessReview, _ metav1.CreateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	sar.Status.Allowed = f.allowed
+	return sar, nil
+}
+
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name        string
+		mapper      apimeta.RESTMapper
+		reviewer    AccessReviewer
+		wantProblem bool
+		wantReason  string
+	}{
+		{
+			name:     "crd present and permitted",
+			mapper:   mapperWith(snippetGVK),
+			reviewer: fakeReviewer{allowed: true},
+		},
+		{
+			name:        "crd not installed",
+			mapper:      mapperWith(), // resolves nothing
+			reviewer:    fakeReviewer{allowed: true},
+			wantProblem: true,
+			wantReason:  "CRD is not installed",
+		},
+		{
+			name:        "rbac forbidden",
+			mapper:      mapperWith(snippetGVK),
+			reviewer:    fakeReviewer{allowed: false},
+			wantProblem: true,
+			wantReason:  "operator ServiceAccount may not list it — grant list+watch in the operator ClusterRole",
+		},
+		{
+			name:        "access review errors",
+			mapper:      mapperWith(snippetGVK),
+			reviewer:    fakeReviewer{err: errors.New("boom")},
+			wantProblem: true,
+			wantReason:  "cannot check RBAC (list): boom",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Checker{Mapper: tt.mapper, Review: tt.reviewer, Logger: slog.Default()}
+			problems := c.Check(context.Background(), []Target{target()})
+			if !tt.wantProblem {
+				if len(problems) != 0 {
+					t.Fatalf("want no problems, got %v", problems)
+				}
+				return
+			}
+			if len(problems) != 1 {
+				t.Fatalf("want 1 problem, got %d: %v", len(problems), problems)
+			}
+			if problems[0].Reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", problems[0].Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestLogUntilReady_ReturnsWhenSatisfied proves the loop exits (does not block)
+// once prerequisites are met.
+func TestLogUntilReady_ReturnsWhenSatisfied(t *testing.T) {
+	c := &Checker{Mapper: mapperWith(snippetGVK), Review: fakeReviewer{allowed: true}, Logger: slog.Default()}
+	done := make(chan struct{})
+	go func() {
+		c.LogUntilReady(context.Background(), []Target{target()}, time.Millisecond)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("LogUntilReady did not return when prerequisites were satisfied")
+	}
+}
+
+// TestLogUntilReady_StopsOnContextCancel proves an unsatisfiable check exits on
+// context cancellation rather than looping forever.
+func TestLogUntilReady_StopsOnContextCancel(t *testing.T) {
+	c := &Checker{Mapper: mapperWith(), Review: fakeReviewer{allowed: false}, Logger: slog.Default()}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		c.LogUntilReady(ctx, []Target{target()}, time.Millisecond)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("LogUntilReady did not stop on context cancel")
+	}
+}


### PR DESCRIPTION
A controller-runtime controller exits the process when a watched source cannot sync within CacheSyncTimeout (default 2m), so a missing CRD or a ClusterRole that can't list/watch a watched type turned into a crash-loop.

Set CacheSyncTimeout effectively unbounded: the manager retries the failing informer for the pod's lifetime instead of exiting, so the failure degrades to "not ready, waiting" (readinessSignal already keeps such a pod NotReady while liveness holds it alive) and self-heals the moment the CRD is installed or the RBAC is granted — no restart. A startup preflight (internal/startupcheck, mirrored with stageset-controller) names the exact missing CRD or forbidden verb, one clear line per resource, instead of raw reflector spam.