### PR TITLE
feat(rbac): declare operator RBAC via kubebuilder markers → config/rb…

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -13,5 +13,7 @@ rules:
   truthy:
     check-keys: false
 ignore:
-  # controller-gen output: machine-generated, long description lines.
+  # controller-gen output: machine-generated (its list indentation and long
+  # description lines don't match these rules, and it's not hand-edited).
   - config/crd/bases/
+  - config/rbac/role.yaml

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -64,6 +64,14 @@ precedence = "override"
 SPDX-FileCopyrightText = "The jaas Authors"
 SPDX-License-Identifier = "0BSD"
 
+# And for the controller-gen-emitted operator ClusterRole (the Helm chart vendors
+# and splits it), rewritten wholesale so it can carry no inline header.
+[[annotations]]
+path = "config/rbac/role.yaml"
+precedence = "override"
+SPDX-FileCopyrightText = "The jaas Authors"
+SPDX-License-Identifier = "0BSD"
+
 # Go's fuzzer materializes interesting inputs under testdata/fuzz/ with
 # hash filenames and no extension. The corpus accumulates over time;
 # every entry is a seed for future runs. No inline header is possible.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jaas
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - jaas.metio.wtf
+  resources:
+  - jsonnetlibraries
+  - jsonnetsnippets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - jaas.metio.wtf
+  resources:
+  - jsonnetlibraries/finalizers
+  - jsonnetsnippets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - jaas.metio.wtf
+  resources:
+  - jsonnetlibraries/status
+  - jsonnetsnippets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - buckets
+  - gitrepositories
+  - ocirepositories
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - externalartifacts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - source.toolkit.fluxcd.io
+  resources:
+  - externalartifacts/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -255,6 +255,29 @@ type SnippetReconciler struct {
 	missingMu sync.RWMutex
 }
 
+// RBAC the operator needs, declared so config/rbac/role.yaml (generated) is the
+// single source of truth the Helm chart vendors its ClusterRoles from. Leader-
+// election (coordination.k8s.io/leases) is deliberately NOT here: it is a
+// release-namespace Role in the chart, which a flat ClusterRole cannot express.
+//
+// +kubebuilder:rbac:groups=jaas.metio.wtf,resources=jsonnetsnippets;jsonnetlibraries,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=jaas.metio.wtf,resources=jsonnetsnippets/status;jsonnetlibraries/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=jaas.metio.wtf,resources=jsonnetsnippets/finalizers;jsonnetlibraries/finalizers,verbs=update
+// The operator fetches Flux sources and publishes an ExternalArtifact per snippet.
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=gitrepositories;ocirepositories;buckets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=externalartifacts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=externalartifacts/status,verbs=get;update;patch
+// The EventRecorder annotates JsonnetSnippets in tenant namespaces; tenant
+// impersonation reads the SA and mints a TokenRequest token for it (no impersonate verb).
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get
+// +kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
+// The crdWatcher subscribes to the CRD stream to engage Flux source watches when
+// their CRDs appear; self-signed webhook mode patches the operator's own VWC caBundle.
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;update
+
 // Reconcile is invoked for every JsonnetSnippet create/update/delete event
 // the manager surfaces to this controller.
 func (r *SnippetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -4,6 +4,10 @@
 # Regenerates every controller-gen artifact this repo commits:
 #   - api/v1/zz_generated.deepcopy.go — DeepCopy implementations
 #   - config/crd/bases/*.yaml         — the CustomResourceDefinitions
+#   - config/rbac/role.yaml           — the operator ClusterRole from the
+#                                       +kubebuilder:rbac markers (scanned across
+#                                       ./... since they live in internal/operator),
+#                                       vendored into the Helm chart's ClusterRoles
 #
 # Run it after any change to api/v1 and commit the result. The `generated` job
 # in verify.yml runs this same command and fails on a diff, so the gate cannot
@@ -19,3 +23,4 @@
 
 go tool controller-gen object paths=./api/v1/...
 go tool controller-gen crd paths=./api/... output:crd:dir=./config/crd/bases
+go tool controller-gen rbac:roleName=jaas paths=./... output:rbac:dir=./config/rbac


### PR DESCRIPTION
…ac/role.yaml

The operator declared no RBAC — its permissions lived only in the hand-authored Helm chart, which nothing kept in sync with the code (the drift class that crash-looped stageset-controller). Add +kubebuilder:rbac markers for every grant the operator needs and generate config/rbac/role.yaml, so the binary is the single source of truth the chart can vendor its ClusterRoles from.

The markers reproduce the chart's tenant + cluster ClusterRole grants exactly (verified rule-by-rule, 48 = 48). Leader-election (coordination.k8s.io/leases) is deliberately excluded: it is a release-namespace Role in the chart, which a flat ClusterRole can't express, and stays hand-authored.