### PR TITLE
fix(operator): say which decision force-dropped the finalizer

### DIFF
--- a/internal/operator/authretry_test.go
+++ b/internal/operator/authretry_test.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -236,6 +237,51 @@ func TestClassifyWithdrawFailure_ForceDropsOnUnauthorized(t *testing.T) {
 	}
 	if info.dropReason != "permanent" {
 		t.Errorf("dropReason = %q, want %q", info.dropReason, "permanent")
+	}
+}
+
+// A classifier drop fires well inside MaxWithdrawWait, so the event must not
+// claim the bound elapsed. Reading "after 21m of failing Withdraw" on a snippet
+// whose bound is an hour reads as the whole window having been spent retrying
+// something that could never succeed — which is not what happened.
+func TestForceDropFinalizer_UnrecoverableDropDoesNotClaimTheBoundElapsed(t *testing.T) {
+	c := clientWithStatus(t, sampleSnippet())
+	r := newReconciler(t, c)
+	rec := events.NewFakeRecorder(8)
+	r.EventRecorder = rec
+
+	r.forceDropFinalizer(context.Background(), discardLogger(), sampleSnippet(), &forceDropInfo{
+		elapsed:       21 * time.Minute,
+		dropReason:    "withdraw_permanent",
+		unrecoverable: true,
+		lastErr:       errors.New("namespace is terminating"),
+	})
+
+	msg := strings.Join(drainEvents(rec), "\n")
+	if strings.Contains(msg, "of failing Withdraw") {
+		t.Errorf("unrecoverable drop worded as a timeout: %q", msg)
+	}
+	if !strings.Contains(msg, "no retry can clear") {
+		t.Errorf("message does not say the retry was pointless: %q", msg)
+	}
+}
+
+// The timeout branch keeps its original wording: there the bound genuinely did
+// elapse.
+func TestForceDropFinalizer_TimeoutDropKeepsItsWording(t *testing.T) {
+	c := clientWithStatus(t, sampleSnippet())
+	r := newReconciler(t, c)
+	rec := events.NewFakeRecorder(8)
+	r.EventRecorder = rec
+
+	r.forceDropFinalizer(context.Background(), discardLogger(), sampleSnippet(), &forceDropInfo{
+		elapsed:    time.Hour,
+		dropReason: "withdraw_timed_out",
+		lastErr:    errors.New("backend unreachable"),
+	})
+
+	if msg := strings.Join(drainEvents(rec), "\n"); !strings.Contains(msg, "of failing Withdraw") {
+		t.Errorf("timeout drop lost its wording: %q", msg)
 	}
 }
 

--- a/internal/operator/reconciler.go
+++ b/internal/operator/reconciler.go
@@ -423,13 +423,15 @@ func (r *SnippetReconciler) classifyWithdrawFailure(snip *jaasv1.JsonnetSnippet,
 	// terminating, which is taking the ExternalArtifact with it anyway. On the
 	// deletion path that is as final as a Forbidden, and holding the finalizer
 	// for it pins the whole namespace behind an object that is already doomed.
+	unrecoverable := false
 	if !forceDrop && (isPermanentAPIError(err) || apierrors.IsUnauthorized(err)) {
 		forceDrop = true
+		unrecoverable = true
 		elapsed = r.now().Sub(snip.DeletionTimestamp.Time)
 		dropReason = permanentReason
 	}
 	if forceDrop {
-		return &forceDropInfo{elapsed: elapsed, dropReason: dropReason, lastErr: wrapped}, nil
+		return &forceDropInfo{elapsed: elapsed, dropReason: dropReason, lastErr: wrapped, unrecoverable: unrecoverable}, nil
 	}
 	return nil, wrapped
 }
@@ -444,6 +446,12 @@ type forceDropInfo struct {
 	dropReason     string
 	lastErr        error
 	storageCleaned bool
+	// unrecoverable records that the classifier decided, not the clock. The two
+	// read very differently to an operator — one means the bound elapsed, the
+	// other that the bound was never going to help — and the dropReason strings
+	// cannot be sniffed for it (the timeout branches are spelled
+	// "tenant_client_timeout" and "withdraw_timed_out").
+	unrecoverable bool
 }
 
 // forgetPerSnippetCaches evicts every cache entry keyed by this snippet
@@ -512,17 +520,27 @@ func (r *SnippetReconciler) withdrawTimedOut(snip *jaasv1.JsonnetSnippet) (bool,
 // logs.
 func (r *SnippetReconciler) forceDropFinalizer(ctx context.Context, logger *slog.Logger, snip *jaasv1.JsonnetSnippet, forced *forceDropInfo) {
 	prefix := snip.Namespace + "/" + snip.Name
+	// Say which decision dropped the finalizer. A classifier drop fires well
+	// inside MaxWithdrawWait, so wording every drop as "after MaxWithdrawWait"
+	// reads as the bound having elapsed — and invites the conclusion that the
+	// whole window was spent retrying something that could never succeed. The
+	// elapsed value is time since deletionTimestamp under either decision.
+	because, headline := "of failing Withdraw", "Force-dropping finalizer after MaxWithdrawWait"
+	if forced.unrecoverable {
+		because = "of a Withdraw failure no retry can clear"
+		headline = "Force-dropping finalizer on an unrecoverable Withdraw failure"
+	}
 	var msg string
 	if forced.storageCleaned {
-		msg = fmt.Sprintf("WithdrawForced after %s of failing Withdraw — finalizer dropped; the stored tarballs were deleted, only the ExternalArtifact could not be removed as the tenant (it is garbage-collected with its namespace, or remove it by hand). Last error: %v", forced.elapsed.Round(time.Second), forced.lastErr)
+		msg = fmt.Sprintf("WithdrawForced after %s %s — finalizer dropped; the stored tarballs were deleted, only the ExternalArtifact could not be removed as the tenant (it is garbage-collected with its namespace, or remove it by hand). Last error: %v", forced.elapsed.Round(time.Second), because, forced.lastErr)
 	} else {
 		orphans := prefix + "/<rev>.tar.gz"
 		if revs := knownRevisionPaths(prefix, snip.Status.History); revs != "" {
 			orphans = revs
 		}
-		msg = fmt.Sprintf("WithdrawForced after %s of failing Withdraw — finalizer dropped; storage may carry orphaned tarballs under %s/ that an operator must remove by hand (known revisions: %s). Last error: %v", forced.elapsed.Round(time.Second), prefix, orphans, forced.lastErr)
+		msg = fmt.Sprintf("WithdrawForced after %s %s — finalizer dropped; storage may carry orphaned tarballs under %s/ that an operator must remove by hand (known revisions: %s). Last error: %v", forced.elapsed.Round(time.Second), because, prefix, orphans, forced.lastErr)
 	}
-	logger.WarnContext(ctx, "Force-dropping finalizer after MaxWithdrawWait",
+	logger.WarnContext(ctx, headline,
 		slog.Duration("elapsed", forced.elapsed),
 		slog.String("reason", forced.dropReason),
 		slog.Bool("storageCleaned", forced.storageCleaned),


### PR DESCRIPTION
Every force-drop was logged as "Force-dropping finalizer after MaxWithdrawWait" and evented as "after <elapsed> of failing Withdraw", including the drops the classifier decides. Those fire well inside the bound — a Forbidden on the tenant TokenRequest while the namespace terminates drops on the first reconcile that sees it — so the wording reads as the bound having elapsed, and invites the conclusion that the whole window was spent retrying something that could never succeed.

It cost a reader exactly that: two drops at 21m57s and 21m52s against an hour-long bound were reported as MaxWithdrawWait being spent on a Forbidden that was terminal from the first attempt. What the elapsed value measures is time since deletionTimestamp under either decision; the retrying in that window was a different, earlier failure.

forceDropInfo now carries the decision explicitly rather than leaving it to be inferred from dropReason, whose timeout branches are spelled "tenant_client_timeout" and "withdraw_timed_out" and so cannot be sniffed for a common suffix.