### PR TITLE
build(container): declare the non-root user each image runs as

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,8 @@ COPY --from=build /app/jaas /usr/bin/
 # The generated CRDs ride along so downstream tooling (the Helm chart's
 # vendoring step) can extract them straight from the released image.
 COPY --from=build /crds /crds
+# The uid distroless's :nonroot tag defaults to, stated rather than inherited: a
+# base image change must not be able to hand the operator root, and a numeric uid
+# is what a pod's runAsNonRoot can check without resolving /etc/passwd.
+USER 65532:65532
 ENTRYPOINT ["/usr/bin/jaas"]

--- a/dashboards/Containerfile
+++ b/dashboards/Containerfile
@@ -9,3 +9,7 @@
 # library images satisfy.
 FROM scratch
 COPY *.jsonnet /
+# The image carries data and runs nothing, but a scratch image inherits no user
+# at all — so anything that does exec it would run as root. USER is metadata, not
+# a filesystem layer, so the single-layer contract above is unaffected.
+USER 65532:65532


### PR DESCRIPTION
The shared policy check now requires the final build stage to name a non-root USER, because a base image's default is silent and changes when the base does: an image that never says USER can gain root without a line of its Containerfile changing, and neither the build nor the tests would notice.

Neither image gains or loses a privilege here. distroless's :nonroot tag already defaults to uid 65532 — the same uid the chart pins in the pod's securityContext — so stating it keeps the two in agreement and makes a base image swap unable to change the answer quietly. A numeric uid is also what runAsNonRoot can verify without resolving /etc/passwd, which a distroless image barely has.

The dashboard image ships data and runs nothing, but scratch inherits no user at all, so anything that did exec it would run as root. USER is metadata rather than a filesystem layer, so the single-layer contract that lets the image serve as both an OCIRepository source and an image-volume mount is untouched — a local build still reports exactly one layer.